### PR TITLE
docs: architecture OCR/IDP incrémental

### DIFF
--- a/docs/architecture/merge-decision-table.md
+++ b/docs/architecture/merge-decision-table.md
@@ -1,0 +1,254 @@
+# Tableau de décision -- Merge incrémental
+
+> Référence pour le `MergeEngine` (domaine pur, `backend/internal/domain/chapter/merge.go`).
+> Chaque règle est exécutée dans l'ordre de priorité. La première règle qui matche est appliquée.
+
+---
+
+## Métriques utilisées
+
+| Métrique | Définition | Calcul |
+|----------|-----------|--------|
+| **CanonicalKey match** | Les deux items ont le même `CanonicalKey(term, item_type, pack_id)` | `identity.go` : lowercase + NFD accent removal + trim |
+| **Jaccard(keywords)** | Coefficient de Jaccard entre les ensembles de keywords | `|A ∩ B| / |A ∪ B|` |
+| **Confidence delta** | Différence de confiance entre le nouvel item et l'existant | `new.confidence - existing.confidence` |
+| **Text similarity** | Similarité textuelle entre les `ocr_text` des blocs sources | Jaccard sur les mots normalisés (après stopwords removal) |
+
+---
+
+## Tableau de décision
+
+| # | Condition | Action | Automatique ? | Domain Event | Impact Mastery | Référence AC |
+|---|-----------|--------|---------------|--------------|----------------|-------------|
+| **R1** | CanonicalKey match **ET** Jaccard(keywords) > 0.85 | **ARCHIVE_DUP** : archiver l'item de plus faible confiance | Oui | `ItemArchived` | Transfert Mastery vers survivant (le plus avancé) | Z3-AC11 |
+| **R2** | CanonicalKey match **ET** Jaccard(keywords) 0.50-0.85 **ET** `new.confidence > existing.confidence + 0.15` | **REPLACE** : remplacer l'ancien par le nouveau (meilleure extraction) | Oui | `ItemReplaced` | Transfert Mastery vers nouveau | Z2-AC14 |
+| **R3** | CanonicalKey match **ET** Jaccard(keywords) 0.50-0.85 **ET** confidence delta < 0.15 | **ENRICH** : fusionner les keywords du nouveau dans l'existant, ajouter `source_refs` | Oui | `ItemsEnriched` | Inchangé | Z2-AC14 |
+| **R4** | CanonicalKey match **ET** Jaccard(keywords) < 0.50 | **FLAG_CONFLICT** : possible contradiction sémantique (même terme, contenu très différent) | Non (HITL) | `ConflictDetected` | Gelé (pas de transition) | Z3-AC11 |
+| **R5** | CanonicalKey miss **ET** Jaccard(keywords) > 0.70 **ET** termes proches (edit distance < 3) | **FLAG_CONFLICT** : probable doublon avec formulation différente | Non (HITL si confiance < 0.7) | `ConflictDetected` | Gelé | Z3-AC11 |
+| **R6** | CanonicalKey miss **ET** Jaccard(keywords) 0.50-0.70 | **CREATE_ALT** : créer comme item alternatif en attente de review | Non (HITL) | Aucun | Aucun (pas de Mastery créé tant que non validé) | Z3-AC11 |
+| **R7** | CanonicalKey miss **ET** Jaccard(keywords) < 0.50 | **APPEND** : nouvel item, nouvelle connaissance | Oui | `ItemsGenerated` | Nouveau Mastery UNKNOWN | Z2-AC14 |
+
+---
+
+## Diagramme de décision
+
+```
+Nouvel item extrait
+        │
+        ▼
+CanonicalKey match avec un item existant ?
+        │
+   ┌────┴────┐
+   │ OUI     │ NON
+   ▼         ▼
+Jaccard    Jaccard(keywords) avec tous les existants
+keywords?       │
+   │       ┌───┼───┐───────┐
+   │       │   │   │       │
+   │     >0.70 │ 0.50-0.70 │ <0.50
+   │       │   │   │       │
+   │       ▼   │   ▼       ▼
+   │     R5:   │  R6:     R7:
+   │    FLAG   │ CREATE   APPEND
+   │  CONFLICT │  ALT      │
+   │       │   │   │    ItemsGenerated
+   │       │   │   │    Mastery UNKNOWN
+   │       │   │   │
+   ├───────┤   │   │
+   │       │   │   │
+   │ >0.85 │ 0.50-0.85   <0.50
+   │       │       │        │
+   ▼       ▼       ▼        ▼
+  R1:     ∆conf   R4:
+ ARCHIVE  > 0.15? FLAG
+  DUP     │       CONFLICT
+   │   ┌──┴──┐
+   │   OUI  NON
+   │    │    │
+   ▼    ▼    ▼
+  R1   R2:  R3:
+      REPLACE ENRICH
+```
+
+---
+
+## Détails par action
+
+### R1 : ARCHIVE_DUP (doublon exact)
+
+**Quand** : même terme normalisé, même type, et keywords quasi-identiques.
+
+**Algorithme** :
+1. Comparer `CanonicalKey(new) == CanonicalKey(existing)`.
+2. Calculer `Jaccard(new.keywords, existing.keywords)`.
+3. Si Jaccard > 0.85, c'est un doublon.
+4. Archiver celui avec la confiance la plus basse (`item.Archive(now)`).
+5. Si confiances égales (delta < 0.05), archiver le plus récent (conserver l'original).
+
+**Exemple** :
+- Existant : `term="Chloroplaste"`, keywords=["organite", "cellule végétale", "chlorophylle"], confidence=0.90
+- Nouveau : `term="chloroplaste"`, keywords=["organite", "cellule", "chlorophylle", "photosynthèse"], confidence=0.85
+- CanonicalKey match : oui (`chloroplaste|KNOWLEDGE|SVT-PHOTO`)
+- Jaccard = |{organite, chlorophylle}| / |{organite, cellule végétale, cellule, chlorophylle, photosynthèse}| = 2/5 = 0.40
+- Jaccard < 0.85 donc **pas R1**, on passe à R3 (ENRICH).
+
+**Contre-exemple** (vrai doublon) :
+- Existant : keywords=["organite", "cellule végétale", "chlorophylle", "photosynthèse"]
+- Nouveau : keywords=["organite", "cellule végétale", "chlorophylle"]
+- Jaccard = 3/4 = 0.75 -- toujours pas > 0.85.
+- Pour atteindre R1, il faut vraiment que les keywords soient quasi-identiques : Jaccard > 0.85 signifie que le nouveau n'apporte essentiellement rien de neuf.
+
+### R2 : REPLACE (meilleure extraction)
+
+**Quand** : même terme, keywords partiellement similaires, mais la nouvelle extraction est significativement meilleure.
+
+**Algorithme** :
+1. CanonicalKey match.
+2. Jaccard(keywords) entre 0.50 et 0.85.
+3. `new.confidence - existing.confidence > 0.15`.
+4. L'ancien item est archivé, le nouveau prend sa place.
+5. Le Mastery est transféré.
+
+**Cas typique** : l'élève re-photographie une page floue (confiance 0.55) avec une meilleure photo (confiance 0.88). Delta = 0.33 > 0.15 donc REPLACE.
+
+**Seuil de 0.15** : calibré pour éviter les remplacements sur du bruit. Un delta de 0.05-0.10 peut être dû à la variance OCR sur la même page.
+
+### R3 : ENRICH (enrichissement)
+
+**Quand** : même terme, keywords partiellement similaires, confiances proches.
+
+**Algorithme** :
+1. CanonicalKey match.
+2. Jaccard(keywords) entre 0.50 et 0.85.
+3. Delta confiance <= 0.15.
+4. Les keywords du nouveau qui ne sont pas dans l'existant sont ajoutés.
+5. Les `source_refs` du nouveau sont ajoutés à l'existant.
+6. La confiance est mise à jour : `max(existing.confidence, new.confidence)`.
+
+**Exemple** :
+- Existant : `term="Stomate"`, keywords=["orifice", "feuille", "échanges gazeux"]
+- Nouveau (depuis correction d'exercice) : `term="Stomate"`, keywords=["orifice", "feuille", "CO₂", "O₂", "face inférieure"]
+- Jaccard = |{orifice, feuille}| / |{orifice, feuille, échanges gazeux, CO₂, O₂, face inférieure}| = 2/6 = 0.33
+- Jaccard < 0.50, donc c'est en fait R4 (FLAG_CONFLICT), pas R3.
+- Mais les CanonicalKeys matchent et le contenu n'est pas contradictoire (il enrichit).
+- **Correction** : quand le CanonicalKey matche, si les keywords sont complémentaires (pas contradictoires) et que le delta de confiance est faible, on fait ENRICH même avec un Jaccard < 0.50. La règle R4 ne s'applique que quand il y a une **contradiction sémantique détectée** (via le CoherenceChecker LLM), pas juste un faible Jaccard.
+
+### R3 ajusté : ENRICH (version corrigée)
+
+**Condition réelle** :
+1. CanonicalKey match.
+2. Pas de contradiction détectée par le CoherenceChecker.
+3. Delta confiance <= 0.15.
+4. -> ENRICH (fusionner keywords + source_refs).
+
+**Condition R4 réelle** :
+1. CanonicalKey match.
+2. Contradiction détectée par le CoherenceChecker (contenu sémantiquement incompatible).
+3. -> FLAG_CONFLICT.
+
+Le Jaccard sert de **pré-filtre** pour décider s'il faut appeler le CoherenceChecker LLM (coûteux). Si Jaccard > 0.85, pas besoin de checker (doublon évident). Si Jaccard < 0.50 avec CanonicalKey match, le CoherenceChecker est appelé pour distinguer enrichissement de contradiction.
+
+### R4 : FLAG_CONFLICT (contradiction)
+
+**Quand** : même terme, mais le CoherenceChecker LLM détecte une contradiction sémantique.
+
+**Exemple** :
+- Existant : `term="Densité"`, definition: "masse divisée par le volume" (correct)
+- Nouveau : `term="Densité"`, definition: "volume divisé par la masse" (incorrect)
+- CanonicalKey match.
+- CoherenceChecker retourne : contradiction, severity=0.9.
+- Les deux items sont flaggés `coherence_flag='contradiction'`, `validation_required=true`.
+- ValidationTask créée (Z3-AC11).
+
+### R5 : FLAG_CONFLICT (doublon avec formulation différente)
+
+**Quand** : termes différents mais keywords très proches.
+
+**Exemple** :
+- Existant : `term="Masse volumique"`, keywords=["masse", "volume", "rho", "kg/m³"]
+- Nouveau : `term="Densité"`, keywords=["masse", "volume", "rho", "eau"]
+- CanonicalKey miss (termes différents).
+- Jaccard = |{masse, volume, rho}| / |{masse, volume, rho, kg/m³, eau}| = 3/5 = 0.60
+- Wait, 0.60 < 0.70 donc c'est R6, pas R5.
+- Pour R5, il faudrait Jaccard > 0.70 : par exemple deux formulations d'un même concept avec les mêmes keywords.
+
+### R6 : CREATE_ALT (alternative en attente)
+
+**Quand** : pas de match exact, mais similarité modérée. Possible enrichissement ou possible concept distinct.
+
+**Algorithme** :
+1. Créer le nouvel item avec `merge_status='alternative'`.
+2. Ne pas créer de Mastery (item non validé).
+3. Si confiance >= 0.70, pas de HITL (l'alternative est simplement conservée).
+4. Si confiance < 0.70, créer une ValidationTask pour que l'élève/parent décide.
+
+### R7 : APPEND (nouveau concept)
+
+**Quand** : aucune similarité significative avec les items existants.
+
+**Algorithme** :
+1. Créer l'item avec `merge_status='original'`.
+2. Rattacher à une Notion existante (par nom) ou créer une nouvelle Notion.
+3. Émettre `ItemsGenerated`.
+4. Créer un Mastery UNKNOWN pour l'utilisateur.
+
+---
+
+## Ordre d'évaluation
+
+Les règles sont évaluées dans l'ordre R1-R7 pour chaque item entrant. La première règle qui matche est appliquée.
+
+Pour chaque item entrant, le MergeEngine :
+1. Calcule le CanonicalKey du nouvel item.
+2. Cherche un item existant avec le même CanonicalKey.
+3. Si trouvé : calcule Jaccard, applique R1/R2/R3/R4.
+4. Si non trouvé : calcule Jaccard avec tous les existants, applique R5/R6/R7.
+
+**Complexité** : O(n*m) où n = items entrants, m = items existants. Pour un chapitre typique (5-20 items), c'est négligeable.
+
+---
+
+## Seuils récapitulatifs
+
+| Seuil | Valeur | Justification |
+|-------|--------|---------------|
+| Jaccard doublon | > 0.85 | Très peu de keywords différents = même contenu |
+| Jaccard enrichissement | 0.50-0.85 | Keywords complémentaires = enrichissement probable |
+| Jaccard matching cross-term | > 0.70 | Même concept, formulation différente |
+| Jaccard modéré cross-term | 0.50-0.70 | Zone grise, nécessite review |
+| Jaccard pas de match | < 0.50 | Concepts distincts |
+| Confidence delta replace | > 0.15 | Écart significatif, pas du bruit OCR |
+| Confidence HITL obligatoire | < 0.50 | Extraction trop incertaine |
+| Confidence pas de HITL | >= 0.85 | Extraction fiable (Z3-AC09) |
+| OCR confidence floue | < 0.30 | Page floue (Z2-AC03) |
+| Text similarity re-photo | > 0.80 | Même page re-photographiée |
+| Edit distance termes proches | < 3 | Typo ou variante orthographique |
+
+---
+
+## Cas limites
+
+### Cas 1 : Item PROCEDURE avec même terme mais étapes différentes
+
+Un item PROCEDURE "Calcul de la densité" peut avoir des étapes différentes selon la source (méthode du prof vs. méthode du manuel). Dans ce cas :
+- Le CanonicalKey matche.
+- Les keywords matchent (Jaccard > 0.50).
+- Mais les `steps` divergent.
+
+**Décision** : le CoherenceChecker compare les steps. Si les steps sont compatibles (un est un sous-ensemble de l'autre), c'est un ENRICH. Si les steps sont contradictoires, c'est un FLAG_CONFLICT.
+
+### Cas 2 : Item DOCUMENT (schéma) re-extrait
+
+Un schéma re-photographié produit un nouvel item DOCUMENT avec un visual_block_id différent mais le même `term`. Dans ce cas :
+- CanonicalKey matche.
+- On compare les `ocr_confidence` des blocs sources.
+- Si le nouveau crop est de meilleure qualité (confidence > old + 0.15), REPLACE.
+- Sinon, on garde l'existant (le premier crop suffit).
+
+### Cas 3 : Fiche de correction qui enrichit des items existants
+
+Une correction d'exercice (Session 3 dans l'exemple photosynthèse) reprend des définitions déjà extraites. Dans ce cas :
+- Les CanonicalKeys matchent pour les items repris.
+- La correction confirme les définitions existantes (pas de contradiction).
+- Action = ENRICH : on ajoute la page de correction comme `source_ref` supplémentaire.
+- La confiance peut augmenter (cross-validation par une source supplémentaire).

--- a/docs/architecture/ocr-idp-incremental.md
+++ b/docs/architecture/ocr-idp-incremental.md
@@ -1,0 +1,769 @@
+# Architecture OCR/IDP incrémental -- Révise Mieux
+
+> Document d'architecture technique pour le pipeline d'ingestion incrémental de contenu scolaire.
+> Dernière mise à jour : 2026-04-03.
+
+---
+
+## 1. Executive Summary
+
+Révise Mieux ingère des photos de cahiers de collégiens pour en faire des assets de révision structurés. Le problème central n'est pas l'OCR lui-même -- c'est l'ingestion **incrémentale dans le temps** : un élève ajoute des pages jour après jour, re-photographie des pages floues, et complète son cours sur des semaines. Le système doit intégrer chaque batch sans régénérer le chapitre entier, tout en maintenant la cohérence des Notions, Items et Mastery existants.
+
+Ce document définit : (1) un format pivot canonique entre OCR et LLM, (2) le workflow d'ingestion incrémentale en 10 étapes, (3) les règles de merge avec seuils concrets, (4) l'impact sur les Mastery existants, (5) l'intégration avec le bounded context Validation (HITL), et (6) les signatures Go et migrations SQL nécessaires.
+
+**Modèles retenus** : Gemini 2.5 Flash (OCR, $0.001/page) + mistral-small ou Qwen3.5-397B (IDP, $0.00006-0.00011/item). Pipeline local viable via Qwen3-VL-32B + Gemma 3 27B ($0, ~2 min/chapitre).
+
+---
+
+## 2. Cadrage du problème
+
+### 2.1 OCR éducatif vs. extraction documentaire générique
+
+L'OCR/IDP éducatif diffère de l'extraction de factures ou de formulaires sur plusieurs axes fondamentaux :
+
+| Dimension | IDP générique (factures) | IDP éducatif (cahiers) |
+|-----------|--------------------------|------------------------|
+| **Structure** | Champs fixes, positions connues | Structure libre, variable selon le prof |
+| **Contenu** | Données factuelles (montants, dates) | Connaissances sémantiques (définitions, procédures, concepts) |
+| **Visuels** | Logos, signatures (non pertinents) | Schémas porteurs de sens (cellule, circuit, carte) |
+| **Manuscrit** | Rare (signatures) | Dominant (notes élève, corrections prof) |
+| **Temporalité** | Document unique, ponctuel | Cours construit sur des semaines, incrémental |
+| **Qualité cible** | Extraction exacte de champs | Compréhension sémantique pour générer des exercices |
+| **Conséquence erreur** | Montant incorrect (corrigible) | Élève qui apprend une erreur (pédagogiquement dangereux) |
+
+### 2.2 Ce qui rend l'ingestion incrémentale difficile
+
+1. **Uploads partiels** : 3 pages lundi, 2 mercredi, 1 vendredi -- le cours est construit dans le temps.
+2. **Pages dans le désordre** : l'élève photographie la page 5 avant la page 2.
+3. **Contenu dupliqué** : re-photographie d'une page floue, ou même notion vue dans deux parties du cours.
+4. **Contenu contradictoire** : corrections du prof qui contredisent la version initiale.
+5. **Incertitude OCR variable** : confiance 0.95 sur du texte imprimé, 0.4 sur du manuscrit raturé.
+6. **Schémas porteurs de sens** : un schéma de cellule sans son texte OCR perd 50% de sa valeur pédagogique.
+7. **Traçabilité obligatoire** : chaque Item doit pouvoir pointer vers sa page source (Z2-AC13).
+8. **Stabilité des identifiants** : les Notion IDs et Item IDs ne doivent pas changer quand de nouvelles pages arrivent.
+
+### 2.3 Risques d'une architecture mal conçue
+
+- **Fragmentation progressive** : le cours se décompose en sous-ensembles incohérents au fil des uploads.
+- **Doublons Mastery** : un Item dupliqué produit deux Mastery indépendants pour la même connaissance.
+- **Régression silencieuse** : un re-processing complet change les Item IDs, ce qui reset tous les Mastery.
+- **Coût exponentiel** : re-traiter tout le chapitre à chaque ajout de page (O(n) au lieu de O(delta)).
+- **Dérive pédagogique** : des Items contradictoires coexistent, l'élève étudie du contenu faux.
+
+---
+
+## 3. Architecture recommandée
+
+### 3.1 Architecture 2 étages avec format pivot
+
+```mermaid
+graph TD
+    subgraph "Étage 1 : Extraction (vision)"
+        A[Photo page] -->|S3 upload| B[Gemini 2.5 Flash / Qwen3-VL-32B]
+        B -->|Markdown structuré| C[PivotDocument OCR layer]
+    end
+
+    subgraph "Étage 2 : Structuration (texte)"
+        C -->|Blocs texte + descriptions visuelles| D[mistral-small / Qwen3.5-397B]
+        D -->|Items + Notions| E[PivotDocument pedagogical layer]
+    end
+
+    subgraph "Étage 3 : Merge incrémental"
+        E -->|Nouveaux items| F{Merge Engine}
+        G[Existing PivotDocument] -->|État actuel| F
+        F -->|append/enrich/replace/flag| H[Updated PivotDocument]
+        F -->|conflicts| I[ValidationTask HITL]
+    end
+
+    subgraph "Downstream"
+        H -->|Domain events| J[Mastery creation/update]
+        H -->|Cache invalidation| K[Question lazy generation]
+        I -->|HITL resolution| H
+    end
+```
+
+### 3.2 Couches immutables vs mutables
+
+Le format pivot sépare trois couches avec des règles de mutabilité distinctes :
+
+| Couche | Mutabilité | Contenu | Justification |
+|--------|-----------|---------|---------------|
+| **Observations brutes** | **Immutable** | OCR text, bounding boxes, confiance, timestamps | Traçabilité. On ne modifie jamais ce que l'OCR a vu. |
+| **Structure pédagogique** | **Mutable enrichissable** | Notions, Items, hiérarchie de sections | Enrichie quand de nouvelles pages arrivent. Les IDs sont stables. |
+| **Outputs dérivés** | **Régénérable** | Questions, fiches, quiz, cache Redis | Invalidés et régénérés à la demande (lazy generation). |
+
+**Principe** : les observations brutes (table `blocks`) ne sont jamais modifiées après création. Elles servent de "ground truth" pour la traçabilité. La structure pédagogique (tables `items`, `notions`) évolue par merge incrémental. Les outputs dérivés (table `questions`, cache Redis) sont invalidés et régénérés quand la structure change.
+
+---
+
+## 4. Design du format pivot canonique
+
+### 4.1 Principes
+
+1. **JSON** -- machine-friendly, inspectable, compatible avec tous les LLM.
+2. **Enveloppe par Chapter** -- un PivotDocument = un Chapter complet à un instant t.
+3. **Versionné** -- chaque mutation incrémente `pivot_version`.
+4. **Traçable** -- chaque unité extraite pointe vers ses `source_refs` (Page ID + bbox).
+5. **Confiance explicite** -- `confidence` sur chaque bloc et item, utilisée pour les décisions de merge.
+6. **Compatible context windows** -- le pivot d'un chapitre de 10 pages tient dans ~8K tokens (compatible Gemma 3 27B, 128K context).
+
+### 4.2 Structure du PivotDocument
+
+Le PivotDocument n'est pas une table SQL séparée. C'est le **modèle conceptuel** qui décrit comment les tables existantes (`chapters`, `chapter_revisions`, `pages`, `blocks`, `items`, `notions`) s'articulent pour former une vue canonique du cours. Le JSON Schema (voir `pivot-format-schema.json`) décrit cette vue pour le debugging, les tests, et l'export.
+
+Les tables SQL existantes restent la source de vérité. Le PivotDocument est une **projection** assemblée à la demande.
+
+### 4.3 Sections du pivot
+
+```
+PivotDocument
+├── metadata (chapter_id, subject, class_level, title, pivot_version, updated_at)
+├── capture_sessions[] (immutable)
+│   ├── revision_id, captured_at
+│   └── pages[]
+│       ├── page_id, page_order, photo_url, ocr_status, ocr_confidence
+│       └── blocks[] (immutable observations)
+│           ├── block_id, block_type, ocr_text, confidence, bbox
+│           └── visual_metadata? (labels, table_structure, caption)
+├── notions[] (mutable, stable IDs)
+│   ├── notion_id, name, concept_tags[], sort_order
+│   └── items[]
+│       ├── item_id, item_type, term, keywords[], steps[], confidence
+│       ├── source_refs[] (page_id + block_ids → traçabilité)
+│       ├── fidelity_score, validation_required, archived
+│       └── merge_status (original | enriched | replaced | conflict)
+└── merge_log[] (audit trail)
+    ├── timestamp, action (append | enrich | replace | archive_dup | flag_conflict)
+    ├── source_item_id, target_item_id?
+    └── reason
+```
+
+---
+
+## 5. JSON Schema et exemples
+
+Voir les fichiers compagnons :
+- `pivot-format-schema.json` -- JSON Schema complet
+- `pivot-format-example-photosynthese.json` -- Exemple concret sur "La photosynthèse" avec 3 sessions de capture
+
+---
+
+## 6. Workflow d'ingestion incrémentale
+
+### 6.1 Diagramme de séquence
+
+```mermaid
+sequenceDiagram
+    participant E as Élève
+    participant API as Backend API
+    participant S3 as Object Storage
+    participant OCR as Gemini Flash / Qwen3-VL
+    participant IDP as mistral-small / Qwen3.5
+    participant Merge as Merge Engine
+    participant DB as PostgreSQL
+    participant Redis as Redis Cache
+    participant HITL as Validation BC
+
+    E->>API: POST /chapters/{id}/pages (3 nouvelles photos)
+    API->>S3: Upload photos
+    API->>DB: Insert pages (status=UPLOADING)
+    API-->>E: 202 Accepted (SSE stream started)
+
+    loop Pour chaque nouvelle page
+        API->>OCR: ProcessPage(image_url)
+        OCR-->>API: OCRResult{blocks[], confidence}
+        API->>DB: Insert blocks (immutable)
+        API->>DB: Update page status → PROCESSED
+        API-->>E: SSE: page_processed {page_id, block_count}
+    end
+
+    API->>IDP: StructureBlocks(new_blocks, existing_context)
+    IDP-->>API: StructurationResult{items[], notions[]}
+
+    API->>DB: Load existing items + notions for chapter
+    API->>Merge: MergeIncremental(existing, new)
+    Merge-->>API: MergeResult{appended, enriched, replaced, conflicts, duplicates}
+
+    alt Conflits détectés
+        API->>HITL: CreateValidationTasks(conflicts)
+        API->>DB: Flag conflicting items
+    end
+
+    API->>DB: Save merged items + notions
+    API->>Redis: Invalidate question cache (impacted item_ids only)
+    API->>DB: Publish domain events (ItemsGenerated, NotionMerged, etc.)
+    API-->>E: SSE: merge_complete {new_items, updated_notions}
+```
+
+### 6.2 Détail des 10 étapes
+
+#### Étape 1 : Upload et stockage (S3 + pages table)
+
+- **Toujours recalculé** : upload S3, création entrées `pages`.
+- **Réutilisable** : rien (nouvelles pages).
+- **Invalidé** : rien encore.
+
+Les photos sont stockées dans S3 avec la clé `chapters/{chapter_id}/revisions/{revision_id}/pages/{page_order}.webp`. Les métadonnées sont insérées dans la table `pages` avec `ocr_status = UPLOADING`.
+
+#### Étape 2 : Rattachement au Chapter existant
+
+Les nouvelles pages sont rattachées à la Revision courante du Chapter (Z2-AC14 : pas de nouvelle Revision pour un ajout incrémental). L'`page_order` continue depuis le dernier numéro existant.
+
+- **Réutilisé** : le Chapter et la Revision existants.
+- **Invalidé** : rien.
+
+#### Étape 3 : OCR / analyse de layout (VLM page entière)
+
+Chaque page est envoyée au VLM (Gemini 2.5 Flash en API, Qwen3-VL-32B en local) qui produit du Markdown structuré avec descriptions des visuels.
+
+- **Toujours recalculé** : OCR sur les nouvelles pages uniquement (Z2-AC14).
+- **Réutilisé** : les résultats OCR des pages existantes (jamais re-OCRisées).
+- **Invalidé** : rien encore.
+
+#### Étape 4 : Extraction de blocs (table `blocks`)
+
+Les blocs OCR sont insérés dans la table `blocks`. Ils sont **immutables** après insertion.
+
+- **Toujours recalculé** : parsing du Markdown OCR en blocs structurés.
+- **Réutilisé** : blocs des pages existantes.
+- **Invalidé** : rien.
+
+#### Étape 5 : Structuration pédagogique (LLM IDP)
+
+Le LLM de structuration (mistral-small / Qwen3.5-397B) reçoit les blocs des nouvelles pages **plus** un résumé du contexte existant (noms des Notions existantes, termes des Items existants) pour assurer la cohérence.
+
+```
+Prompt IDP enrichi (mode incrémental) :
+  - System: instructions d'extraction + schéma JSON
+  - Context: "Ce chapitre contient déjà les notions : [liste]. Items existants : [termes]."
+  - Input: blocs OCR des nouvelles pages
+  - Output: nouveaux items + rattachement aux notions existantes ou nouvelles
+```
+
+- **Toujours recalculé** : structuration des nouveaux blocs.
+- **Réutilisé** : items et notions existants (fournis en contexte, pas re-générés).
+- **Invalidé** : rien directement.
+
+#### Étape 6 : Matching avec les structures existantes
+
+Le Merge Engine compare les nouveaux items avec les existants en utilisant :
+1. `CanonicalKey(term, item_type, pack_id)` -- matching exact (identité.go existant).
+2. Similarité cosinus sur les keywords (Jaccard > 0.7) -- matching sémantique léger.
+3. Confiance relative -- pour décider append vs replace.
+
+Voir la section 7 (Règles de merge) pour les seuils détaillés.
+
+#### Étape 7 : Merge / append / split / gestion de conflits
+
+Le résultat du merge produit 6 types d'actions possibles (voir `merge-decision-table.md`).
+
+- **Toujours recalculé** : la comparaison nouveaux vs existants.
+- **Réutilisé** : les Items existants non impactés restent inchangés.
+- **Invalidé** : cache Redis des questions pour les items modifiés/enrichis.
+
+#### Étape 8 : Review basée sur la confiance (HITL)
+
+Les items avec `merge_status = conflict` ou `confidence < 0.5` génèrent des `ValidationTask` dans le bounded context Validation.
+
+- `source = 'coherence_check'` pour les contradictions (Z3-AC11).
+- `source = 'fidelity_check'` pour les items de faible fidélité (Z3-AC10).
+
+#### Étape 9 : Invalidation ciblée du cache
+
+Seules les questions liées aux items impactés sont invalidées (Z3-AC07 : invalidation ciblée, pas globale).
+
+```
+Redis keys invalidated:
+  questions:item:{item_id}  -- pour chaque item modifié/enrichi/remplacé
+```
+
+Les questions des items non impactés restent en cache (TTL 24h inchangé).
+
+#### Étape 10 : Publication des domain events
+
+| Event | Condition | Consommateurs |
+|-------|-----------|---------------|
+| `ItemsGenerated` | Nouveaux items créés (append) | Mastery BC (crée Mastery UNKNOWN) |
+| `ItemsEnriched` | Items existants enrichis | Cache invalidation |
+| `ItemArchived` | Doublon détecté et archivé | Mastery BC (transfert) |
+| `ConflictDetected` | Contradiction entre items | Validation BC (crée ValidationTask) |
+| `NotionMerged` | Nouvelle notion fusionnée avec existante | UI refresh |
+| `BatchProcessed` | Fin du traitement incrémental | SSE notification élève |
+
+---
+
+## 7. Règles de merge / résolution de conflits
+
+Voir `merge-decision-table.md` pour le tableau complet avec seuils.
+
+### 7.1 Résumé des règles
+
+| Situation | Action | Seuil | Automatique ? |
+|-----------|--------|-------|---------------|
+| Nouveau concept | **Append** | Aucun match (CanonicalKey miss + Jaccard < 0.5) | Oui |
+| Même terme, détails supplémentaires | **Enrich** | CanonicalKey match + new keywords not in existing | Oui |
+| Même terme, meilleure confiance | **Replace** | CanonicalKey match + `new.confidence > old.confidence + 0.15` | Oui |
+| Même terme, définitions contradictoires | **Flag conflict** | CanonicalKey match + fidelity check contradiction | Non (HITL) |
+| Même terme + même keywords | **Mark duplicate** | CanonicalKey match + Jaccard(keywords) > 0.85 | Oui (archive lower confidence) |
+| Terme proche mais pas identique | **Create alternative** | Jaccard(keywords) 0.5-0.85 + terms differ | Non (HITL si confidence < 0.7) |
+
+---
+
+## 8. Continuité du cours dans le temps
+
+### 8.1 Heuristiques de classification des nouvelles pages
+
+Quand de nouvelles pages arrivent, le système doit déterminer leur nature :
+
+| Classification | Heuristique | Action |
+|----------------|-------------|--------|
+| **Enrichissement du même cours** | Même `chapter_id` (explicite par l'élève via Z5-AC11) | Merge incrémental |
+| **Re-photographie** | Similarité OCR > 0.8 avec une page existante du même chapitre | Proposer remplacement si meilleure confiance |
+| **Fiche de correction** | Détection de mots-clés : "correction", "exercice", "corrigé" + contexte temporal post-cours | Tag `is_correction = true`, items type PROCEDURE |
+| **Doublon inter-session** | Même CanonicalKey que des items existants | Merge automatique (archive le doublon) |
+| **Enrichissement tardif** | Upload > 7 jours après le dernier, même chapitre | Merge incrémental + notification "Chapitre mis à jour" |
+
+### 8.2 Points de validation humaine
+
+Le système demande confirmation à l'élève quand :
+1. Une page ressemble fortement à une page existante (similarité > 0.8) : "Cette page ressemble à la page 3 existante. Remplacer ou ajouter ?"
+2. Le contenu semble appartenir à un autre chapitre (LLM detect subject mismatch) : "Ce contenu parle de [sujet]. L'ajouter à [chapitre actuel] ou créer un nouveau chapitre ?"
+3. Plus de 30 jours entre le dernier upload et le nouveau : "Ce chapitre n'a pas été mis à jour depuis [N] jours. Ajouter des pages ou créer un nouveau chapitre ?"
+
+### 8.3 Stabilité des Notion IDs
+
+Les Notion IDs sont **persistants**. Quand de nouvelles pages arrivent :
+- Le LLM IDP reçoit les noms des Notions existantes en contexte.
+- S'il produit un item qui correspond à une Notion existante, il rattache l'item à cette Notion (par nom).
+- Si l'item relève d'un concept nouveau, une nouvelle Notion est créée.
+- Les Notion IDs ne changent jamais. Les noms de Notions peuvent être enrichis (ex: "Photosynthèse" -> "Photosynthèse et respiration cellulaire") si le contenu ajouté justifie un élargissement.
+
+---
+
+## 9. Impact sur les Mastery
+
+### 9.1 Tableau de décision
+
+| Événement | Impact Mastery | Domain event | Justification |
+|-----------|---------------|--------------|---------------|
+| **Nouvel Item** (append) | Mastery créé à UNKNOWN | `ItemsGenerated` | Nouveau contenu = nouvelle compétence à acquérir |
+| **Item enrichi** (enrich) | Mastery **inchangé** | `ItemsEnriched` | L'item reste le même, il est juste plus complet. Le Mastery reflète la maîtrise du concept, pas du détail. |
+| **Item remplacé** (replace) | Mastery **transféré** de l'ancien vers le nouveau | `ItemReplaced` | L'ancien item est archivé. Le Mastery est conservé car le concept est le même, seule la formulation change. |
+| **Item archivé** (doublon) | Mastery du doublon **transféré** vers l'item survivant (Z3-AC11) | `ItemArchived` | Le Mastery le plus avancé (state + consecutive_successes) est conservé. |
+| **Item splitté** | Mastery de l'item source **copié** vers les deux items résultants, rétrogradé de 1 niveau | `ItemSplit` | Le split crée de l'incertitude : l'élève maîtrisait le concept global mais pas nécessairement les deux sous-concepts. |
+| **Conflit détecté** | Mastery **gelé** (pas de transition) tant que non résolu | `ConflictDetected` | Un item sous investigation ne doit pas progresser (Z3-AC12). |
+
+### 9.2 Transfert de Mastery
+
+```go
+// TransferMastery transfers mastery state from a source item to a target item.
+// If both have masteries, the more advanced state is kept.
+// Used when archiving duplicates (Z3-AC11) or replacing items.
+func (s *MasteryService) TransferMastery(ctx context.Context, sourceItemID, targetItemID uuid.UUID) error
+```
+
+Règles de transfert :
+- Si seul le source a un Mastery -> transfert direct.
+- Si les deux ont un Mastery -> on conserve le plus avancé (SOLID > OK > FRAGILE > UNKNOWN).
+- À état égal, on conserve celui avec le plus de `consecutive_successes`.
+- Le Mastery source est soft-deleted (conservé pour audit).
+
+---
+
+## 10. Workflow de review humaine (HITL)
+
+### 10.1 Intégration avec ValidationTask
+
+Le pipeline incrémental crée des `ValidationTask` dans les cas suivants :
+
+| Cas | `source` | `priority` | Résolution |
+|-----|----------|-----------|------------|
+| Contradiction entre items (Z3-AC11) | `coherence_check` | HIGH | Élève/parent choisit la bonne version |
+| Fidelity score < 0.5 (Z3-AC10) | `fidelity_check` | MEDIUM | Confirmer/corriger l'item |
+| Re-photographie ambiguë | `merge_conflict` | LOW | Confirmer remplacement ou ajout |
+| Merge incertain (Jaccard 0.5-0.7) | `merge_conflict` | LOW | Confirmer fusion ou séparation |
+
+### 10.2 Seuils de confiance pour HITL
+
+```
+confidence >= 0.85 → Pas de HITL (Z3-AC09)
+confidence 0.50-0.84 → Item utilisable, gabarits simples uniquement (Z3-AC01)
+confidence < 0.50 → HITL obligatoire, item en attente
+OCR confidence < 0.30 → Page marquée BLURRY (Z2-AC03), suggestion re-photographie
+```
+
+### 10.3 File de validation
+
+La file respecte la contrainte Z2-AC09 (max 8 items) :
+- Les items les plus impactants (proches d'un exam, état FRAGILE) sont priorisés.
+- Les items de merge incrémental ont une priorité inférieure aux items de premier pipeline.
+- Le parent en mode actif reçoit max 3 items/semaine (Z3-AC08).
+
+---
+
+## 11. Impact sur la génération downstream
+
+### 11.1 Invalidation ciblée
+
+Quand le merge incrémental modifie des items :
+
+| Action merge | Questions impactées | Invalidation |
+|-------------|--------------------|----|
+| **Append** (nouvel item) | Aucune existante | Pas d'invalidation. Nouvelles questions générées lazy. |
+| **Enrich** (item enrichi) | Questions de cet item | Invalidation `questions:item:{id}`. Régénération lazy. |
+| **Replace** | Questions de l'ancien item | Invalidation. L'ancien item est archivé, nouvelles questions sur le nouveau. |
+| **Archive dup** | Questions du doublon archivé | Invalidation. Questions du survivant inchangées. |
+| **Conflict** | Questions des deux items | Invalidation. Gabarits restreints (Z3-AC01) en attendant résolution. |
+
+### 11.2 Articulation avec le bounded context Session
+
+Le Session BC consomme les items via le port `chapter.Repository.FindItemsByChapter()`. Les items archivés sont filtrés (`WHERE NOT archived`). Les items en conflit sont restreints aux gabarits simples. Le Session BC n'a pas besoin de connaître le format pivot -- il opère sur les entités `Item` et `Notion` existantes.
+
+---
+
+## 12. Signatures Go des méthodes domaine
+
+### 12.1 Nouveaux domain events
+
+```go
+// backend/internal/domain/event/events.go
+
+// ItemsEnriched is emitted when existing items are enriched with new content.
+type ItemsEnriched struct {
+    BaseEvent
+    ChapterID uuid.UUID
+    ItemIDs   []uuid.UUID
+}
+
+func (e ItemsEnriched) EventName() string { return "items.enriched" }
+
+// ItemReplaced is emitted when an item is replaced by a better extraction.
+type ItemReplaced struct {
+    BaseEvent
+    ChapterID    uuid.UUID
+    OldItemID    uuid.UUID
+    NewItemID    uuid.UUID
+    Reason       string // "higher_confidence", "re_photograph"
+}
+
+func (e ItemReplaced) EventName() string { return "item.replaced" }
+
+// ItemArchived is emitted when a duplicate item is archived.
+type ItemArchived struct {
+    BaseEvent
+    ChapterID    uuid.UUID
+    ArchivedID   uuid.UUID
+    SurvivorID   uuid.UUID
+}
+
+func (e ItemArchived) EventName() string { return "item.archived" }
+
+// ConflictDetected is emitted when contradictory items are found.
+type ConflictDetected struct {
+    BaseEvent
+    ChapterID uuid.UUID
+    ItemIDs   []uuid.UUID
+    Reason    string // "contradiction", "ambiguous_merge"
+}
+
+func (e ConflictDetected) EventName() string { return "conflict.detected" }
+
+// NotionMerged is emitted when a new notion is merged into an existing one.
+type NotionMerged struct {
+    BaseEvent
+    ChapterID    uuid.UUID
+    SourceID     uuid.UUID
+    TargetID     uuid.UUID
+}
+
+func (e NotionMerged) EventName() string { return "notion.merged" }
+
+// BatchProcessed is emitted when an incremental batch finishes processing.
+type BatchProcessed struct {
+    BaseEvent
+    ChapterID   uuid.UUID
+    RevisionID  uuid.UUID
+    PageIDs     []uuid.UUID
+    NewItems    int
+    Enriched    int
+    Conflicts   int
+}
+
+func (e BatchProcessed) EventName() string { return "batch.processed" }
+```
+
+### 12.2 Merge Engine (domain service)
+
+```go
+// backend/internal/domain/chapter/merge.go
+
+// MergeAction represents the type of merge operation performed.
+type MergeAction string
+
+const (
+    MergeAppend      MergeAction = "APPEND"
+    MergeEnrich      MergeAction = "ENRICH"
+    MergeReplace     MergeAction = "REPLACE"
+    MergeFlagConflict MergeAction = "FLAG_CONFLICT"
+    MergeArchiveDup  MergeAction = "ARCHIVE_DUP"
+    MergeCreateAlt   MergeAction = "CREATE_ALT"
+)
+
+// MergeDecision represents a single merge decision for one item.
+type MergeDecision struct {
+    Action       MergeAction
+    NewItem      *StructuredItem
+    ExistingItem *Item      // nil for APPEND
+    Confidence   float32
+    Reason       string
+}
+
+// MergeResult holds the complete result of an incremental merge operation.
+type MergeResult struct {
+    Appended  []*Item
+    Enriched  []*Item
+    Replaced  []ItemReplacement
+    Archived  []ItemArchival
+    Conflicts []ItemConflict
+}
+
+// ItemReplacement records a replacement decision.
+type ItemReplacement struct {
+    OldItem *Item
+    NewItem *Item
+    Reason  string
+}
+
+// ItemArchival records a duplicate archival.
+type ItemArchival struct {
+    Archived *Item
+    Survivor *Item
+}
+
+// ItemConflict records a detected conflict requiring HITL.
+type ItemConflict struct {
+    Items  []*Item
+    Reason string // "contradiction", "ambiguous_merge"
+}
+
+// MergeEngine performs incremental merge of new items into existing chapter content.
+// It is a pure domain service with no infrastructure dependencies.
+type MergeEngine struct{}
+
+// NewMergeEngine creates a new MergeEngine.
+func NewMergeEngine() *MergeEngine {
+    return &MergeEngine{}
+}
+
+// MergeIncremental compares new structured items against existing items
+// and produces merge decisions.
+// existing: current items in the chapter (non-archived).
+// incoming: newly extracted items from the IDP stage.
+// packID: optional pack identifier for canonical key computation.
+func (m *MergeEngine) MergeIncremental(
+    existing []*Item,
+    incoming []StructuredItem,
+    packID *string,
+) *MergeResult
+```
+
+### 12.3 Enhanced LLMService port
+
+```go
+// backend/internal/domain/chapter/ports.go (extended)
+
+// LLMService is the port for LLM-based structuration.
+type LLMService interface {
+    // StructureBlocks takes OCR text blocks and produces structured items and notions.
+    StructureBlocks(ctx context.Context, subject string, blocks []OCRBlock) (*StructurationResult, error)
+
+    // StructureBlocksIncremental takes OCR text blocks and existing context
+    // to produce structured items aligned with existing notions.
+    StructureBlocksIncremental(
+        ctx context.Context,
+        subject string,
+        newBlocks []OCRBlock,
+        existingNotions []string,       // names of existing notions
+        existingTerms []string,          // terms of existing items
+    ) (*StructurationResult, error)
+}
+
+// CoherenceChecker is the port for detecting contradictions between items (Z3-AC11).
+type CoherenceChecker interface {
+    // CheckCoherence compares new items against existing items for contradictions.
+    CheckCoherence(
+        ctx context.Context,
+        existingItems []*Item,
+        newItems []*Item,
+    ) ([]CoherenceIssue, error)
+}
+
+// CoherenceIssue represents a detected coherence problem.
+type CoherenceIssue struct {
+    Type     string    // "contradiction", "duplicate"
+    ItemIDs  []uuid.UUID
+    Detail   string
+    Severity float32   // 0.0-1.0
+}
+```
+
+### 12.4 Application service orchestration
+
+```go
+// backend/internal/app/pipeline_service.go (extended)
+
+// ProcessIncrementalBatch orchestrates the incremental pipeline for new pages.
+// It is the main entry point for Z2-AC14.
+func (s *PipelineService) ProcessIncrementalBatch(
+    ctx context.Context,
+    chapterID uuid.UUID,
+    pageIDs []uuid.UUID,
+) (*event.BatchProcessed, error)
+
+// The method:
+// 1. Loads existing items and notions for the chapter
+// 2. Runs OCR on new pages (ProcessPage per page)
+// 3. Calls StructureBlocksIncremental with existing context
+// 4. Runs MergeEngine.MergeIncremental
+// 5. Runs CoherenceChecker.CheckCoherence (new vs existing only, Z2-AC14)
+// 6. Runs FidelityChecker.CheckFidelity on new items
+// 7. Creates ValidationTasks for conflicts and low-fidelity items
+// 8. Saves merged results
+// 9. Invalidates Redis cache for impacted items
+// 10. Publishes domain events
+```
+
+---
+
+## 13. Migrations SQL
+
+### 13.1 Nouvelles colonnes
+
+```sql
+-- Migration: 003_incremental_merge.sql
+
+-- Add merge tracking to items
+ALTER TABLE items ADD COLUMN merge_status TEXT NOT NULL DEFAULT 'original'
+    CHECK (merge_status IN ('original', 'enriched', 'replaced', 'conflict', 'alternative'));
+ALTER TABLE items ADD COLUMN replaced_by_id UUID REFERENCES items(id);
+ALTER TABLE items ADD COLUMN source_block_ids UUID[] NOT NULL DEFAULT '{}';
+
+-- Add similarity tracking for deduplication
+ALTER TABLE items ADD COLUMN canonical_key TEXT;
+CREATE INDEX idx_items_canonical_key ON items(canonical_key) WHERE NOT archived;
+
+-- Track which blocks contributed to which items (many-to-many)
+CREATE TABLE item_source_blocks (
+    item_id     UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    block_id    UUID NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
+    PRIMARY KEY (item_id, block_id)
+);
+CREATE INDEX idx_item_source_blocks_block ON item_source_blocks(block_id);
+
+-- Merge audit log
+CREATE TABLE merge_log (
+    id              UUID PRIMARY KEY,
+    chapter_id      UUID NOT NULL REFERENCES chapters(id) ON DELETE CASCADE,
+    action          TEXT NOT NULL CHECK (action IN ('append', 'enrich', 'replace', 'archive_dup', 'flag_conflict', 'create_alt')),
+    source_item_id  UUID REFERENCES items(id),
+    target_item_id  UUID REFERENCES items(id),
+    reason          TEXT NOT NULL,
+    confidence      REAL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_merge_log_chapter ON merge_log(chapter_id, created_at);
+
+-- Page similarity tracking for re-photograph detection
+ALTER TABLE pages ADD COLUMN text_fingerprint TEXT; -- hash of OCR text for quick similarity check
+CREATE INDEX idx_pages_fingerprint ON pages(text_fingerprint) WHERE text_fingerprint IS NOT NULL;
+
+-- Add processing_incremental status to revision_status enum
+-- Note: PostgreSQL ALTER TYPE ADD VALUE is not transactional, must be separate
+ALTER TYPE revision_status ADD VALUE IF NOT EXISTS 'PROCESSING_INCREMENTAL';
+```
+
+### 13.2 Backfill canonical keys
+
+```sql
+-- Migration: 004_backfill_canonical_keys.sql
+-- Run once after deploying merge support.
+-- Canonical keys are computed in Go and written back.
+-- This migration adds a trigger placeholder; actual backfill is done by the Go migration job.
+
+-- No-op SQL migration. Backfill is performed by:
+-- go run cmd/migrate/backfill_canonical_keys.go
+```
+
+---
+
+## 14. Risques et mitigations
+
+| # | Risque | Impact | Probabilité | Mitigation |
+|---|--------|--------|------------|------------|
+| 1 | **Merge incorrect** : deux Items différents fusionnés car CanonicalKey identique | Perte de contenu, Mastery incohérent | Moyenne | Le merge est réversible (merge_log). Items archivés soft-delete. Fallback HITL. |
+| 2 | **Conflit non détecté** : contradiction subtile non repérée par le LLM | Élève étudie du contenu faux | Faible (fidelity check catch) | Double filet : fidelity check (Z3-AC10) + détection anomalie par taux d'échec (Z3-AC13). |
+| 3 | **Context window overflow** : chapitre très long (30+ pages) dépasse le contexte du LLM local | IDP tronqué, items manquants | Faible (Lot 0 = 4 chapitres pilotes) | Chunking par Notion. Résumé condensé du contexte existant (noms + termes, pas le texte complet). |
+| 4 | **Latence merge** : le merge engine + coherence check ajoutent de la latence | UX dégradée lors de l'ajout de pages | Moyenne | Coherence check en async (batch). SSE progressive. Merge engine est CPU-bound, pas I/O. |
+| 5 | **Drift OCR** : Gemini Flash change de version, qualité OCR fluctue | Items mal extraits | Moyenne | LLM versioning (Z2-AC13). Monitoring fidelity score. Alertes drift. |
+| 6 | **Fragmentation Notion** : les Notions se multiplient au fil des uploads | Cours illisible, trop de Notions | Moyenne | Cap à 7 Notions/chapitre (Z7-AC15). Fusion automatique des Notions < 2 items. |
+
+---
+
+## 15. Stratégie d'implémentation : MVP vs évolution future
+
+### Phase MVP (Lot 0)
+
+**Scope** : Pipeline linéaire, pas de merge sophistiqué. Re-processing complet si ajout de pages.
+
+| Composant | Implémentation |
+|-----------|---------------|
+| OCR | Gemini 2.5 Flash (API) ou Qwen3-VL-32B (local via Ollama) |
+| IDP | mistral-small (API) ou Gemma 3 27B (local) |
+| Merge | **Aucun**. Ajout de pages = re-run pipeline complet sur toutes les pages du chapitre. Items regénérés from scratch. |
+| Dedup | CanonicalKey uniquement (matching exact sur term + type + pack). Archive automatique des doublons. |
+| HITL | Fidelity check (Z3-AC10) + coherence basique (Z3-AC11, même terme contradictoire). |
+| Mastery impact | Re-génération = nouveaux Item IDs = Mastery reset. Acceptable pour 4 chapitres pilotes. |
+| Format pivot | Pas de PivotDocument formel. Les tables SQL existantes suffisent. |
+
+**Coût** : re-processing de 10 pages = ~$0.02 (API) ou $0 (local). Acceptable pour le Lot 0.
+
+### Phase V2 : Incrémental basique
+
+| Composant | Implémentation |
+|-----------|---------------|
+| Merge | MergeEngine avec les 6 actions (append/enrich/replace/conflict/dup/alt) |
+| IDP | `StructureBlocksIncremental` avec contexte existant |
+| Dedup | CanonicalKey + Jaccard keywords (seuils documentés dans merge-decision-table.md) |
+| Coherence | LLM coherence check (cross-page, nouveaux vs existants uniquement) |
+| Mastery | Transfert de Mastery sur archive/replace. Gel sur conflit. |
+| Merge log | Table `merge_log` pour audit et réversibilité |
+| Format pivot | PivotDocument comme projection (pas de table dédiée) |
+
+### Phase V3 : Knowledge graph éducatif
+
+| Composant | Implémentation |
+|-----------|---------------|
+| Graphe de concepts | Relations typées entre Notions (prérequis, composition, analogie) |
+| Résolution automatique | LLM agent pour résoudre les conflits mineurs sans HITL |
+| Mémoire de cours | Historique complet des mutations avec undo/redo |
+| Cross-chapter | Liens entre Items de chapitres différents de la même matière |
+| Embeddings | Vecteurs sémantiques pour la recherche de similarité (pgvector) |
+
+---
+
+## 16. Recommandation finale
+
+**Pour le Lot 0**, implémenter le pipeline linéaire simple (re-processing complet). Le coût est négligeable sur 4 chapitres pilotes et cela évite la complexité du merge.
+
+**Dès la V2**, implémenter le `MergeEngine` avec les règles de merge documentées ici. C'est le point d'inflexion où l'expérience utilisateur change : l'élève peut ajouter des pages sans perdre sa progression.
+
+**Le format pivot JSON Schema** doit être défini dès maintenant (il l'est dans ce document) car il contraint le contrat entre OCR et IDP. Même si le MVP ne fait pas de merge, le format pivot assure que les données sont structurées correctement pour le merge futur.
+
+**Priorités d'implémentation** :
+1. `CanonicalKey` (déjà implémenté dans `identity.go`)
+2. `MergeEngine` (domaine pur, testable unitairement)
+3. `StructureBlocksIncremental` (extension du port LLMService)
+4. Migration SQL `003_incremental_merge.sql`
+5. `ProcessIncrementalBatch` (orchestration dans app service)
+6. Domain events (`ItemsEnriched`, `ItemReplaced`, `ItemArchived`, `ConflictDetected`)
+7. Intégration HITL (ValidationTask pour conflits de merge)

--- a/docs/architecture/pivot-format-example-photosynthese.json
+++ b/docs/architecture/pivot-format-example-photosynthese.json
@@ -1,0 +1,643 @@
+{
+  "metadata": {
+    "chapter_id": "019e8a3c-7b2d-7000-8001-000000000001",
+    "user_id": "019e8a3c-7b2d-7000-8001-000000000099",
+    "subject": "SVT",
+    "class_level": "5ème",
+    "title": "La photosynthèse",
+    "pack_id": "SVT-PHOTO",
+    "pivot_version": 3,
+    "current_revision_id": "019e8a3c-7b2d-7000-8001-000000000010",
+    "created_at": "2026-03-24T18:30:00Z",
+    "updated_at": "2026-03-28T19:15:00Z"
+  },
+  "capture_sessions": [
+    {
+      "revision_id": "019e8a3c-7b2d-7000-8001-000000000010",
+      "revision_number": 1,
+      "status": "READY",
+      "captured_at": "2026-03-24T18:30:00Z",
+      "pages": [
+        {
+          "page_id": "019e8a3c-7b2d-7000-8001-000000000101",
+          "page_order": 1,
+          "photo_url": "s3://revisemieux/chapters/019e8a3c-7b2d-7000-8001-000000000001/revisions/019e8a3c-7b2d-7000-8001-000000000010/pages/1.webp",
+          "ocr_status": "DONE",
+          "ocr_confidence": 0.88,
+          "text_fingerprint": "sha256:a1b2c3d4e5f6",
+          "blocks": [
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000201",
+              "block_type": "TEXT",
+              "ocr_text": "Chapitre 5 : La photosynthèse\n\nI. Définition\nLa photosynthèse est le processus par lequel les plantes vertes utilisent la lumière du soleil pour transformer le dioxyde de carbone (CO₂) et l'eau (H₂O) en matière organique (glucose) et en dioxygène (O₂).\n\nCe processus se déroule dans les chloroplastes, des organites présents dans les cellules végétales. Les chloroplastes contiennent la chlorophylle, un pigment vert qui capte la lumière.",
+              "confidence": 0.92,
+              "bbox": { "x": 0.05, "y": 0.03, "w": 0.90, "h": 0.45 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000201.webp",
+              "visual_metadata": null
+            },
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000202",
+              "block_type": "TEXT",
+              "ocr_text": "II. Les acteurs de la photosynthèse\n\n- Chloroplastes : organites où se déroule la photosynthèse\n- Chlorophylle : pigment vert qui capte la lumière\n- Stomates : petits orifices sur les feuilles qui permettent les échanges gazeux (entrée CO₂, sortie O₂)\n- Sève brute : transporte l'eau et les sels minéraux depuis les racines",
+              "confidence": 0.89,
+              "bbox": { "x": 0.05, "y": 0.50, "w": 0.90, "h": 0.45 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000202.webp",
+              "visual_metadata": null
+            }
+          ]
+        },
+        {
+          "page_id": "019e8a3c-7b2d-7000-8001-000000000102",
+          "page_order": 2,
+          "photo_url": "s3://revisemieux/chapters/019e8a3c-7b2d-7000-8001-000000000001/revisions/019e8a3c-7b2d-7000-8001-000000000010/pages/2.webp",
+          "ocr_status": "DONE",
+          "ocr_confidence": 0.75,
+          "text_fingerprint": "sha256:b2c3d4e5f6a1",
+          "blocks": [
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000203",
+              "block_type": "SCHEMA",
+              "ocr_text": null,
+              "confidence": 0.82,
+              "bbox": { "x": 0.10, "y": 0.05, "w": 0.80, "h": 0.55 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000203.webp",
+              "visual_metadata": {
+                "visual_type": "diagram",
+                "labels": [
+                  { "text": "Lumière", "position": { "x": 0.50, "y": 0.02 } },
+                  { "text": "CO₂", "position": { "x": 0.15, "y": 0.40 } },
+                  { "text": "H₂O", "position": { "x": 0.15, "y": 0.70 } },
+                  { "text": "O₂", "position": { "x": 0.85, "y": 0.40 } },
+                  { "text": "Glucose (C₆H₁₂O₆)", "position": { "x": 0.85, "y": 0.70 } },
+                  { "text": "Chloroplaste", "position": { "x": 0.50, "y": 0.50 } }
+                ],
+                "caption": "Schéma bilan de la photosynthèse",
+                "alt_text": "Schéma montrant une feuille avec un chloroplaste au centre. Flèches d'entrée : lumière (en haut), CO₂ (à gauche), H₂O (en bas à gauche). Flèches de sortie : O₂ (à droite), glucose C₆H₁₂O₆ (en bas à droite).",
+                "table_structure": null,
+                "axis_labels": null
+              }
+            },
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000204",
+              "block_type": "TEXT",
+              "ocr_text": "III. L'équation bilan\n\n6 CO₂ + 6 H₂O + lumière → C₆H₁₂O₆ + 6 O₂\n\nLa photosynthèse nécessite de la lumière (énergie lumineuse). Elle ne peut pas se dérouler dans l'obscurité.",
+              "confidence": 0.85,
+              "bbox": { "x": 0.05, "y": 0.62, "w": 0.90, "h": 0.35 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000204.webp",
+              "visual_metadata": null
+            }
+          ]
+        },
+        {
+          "page_id": "019e8a3c-7b2d-7000-8001-000000000103",
+          "page_order": 3,
+          "photo_url": "s3://revisemieux/chapters/019e8a3c-7b2d-7000-8001-000000000001/revisions/019e8a3c-7b2d-7000-8001-000000000010/pages/3.webp",
+          "ocr_status": "DONE",
+          "ocr_confidence": 0.91,
+          "text_fingerprint": "sha256:c3d4e5f6a1b2",
+          "blocks": [
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000205",
+              "block_type": "TEXT",
+              "ocr_text": "IV. Définitions à retenir\n\n- Photosynthèse : processus de fabrication de matière organique par les végétaux à partir de CO₂, H₂O et lumière\n- Chloroplaste : organite cellulaire contenant la chlorophylle, lieu de la photosynthèse\n- Chlorophylle : pigment vert responsable de la captation de la lumière\n- Stomate : orifice des feuilles permettant les échanges gazeux\n- Autotrophe : organisme capable de fabriquer sa propre matière organique (les plantes sont autotrophes)\n- Hétérotrophe : organisme qui doit consommer d'autres êtres vivants (les animaux sont hétérotrophes)",
+              "confidence": 0.93,
+              "bbox": { "x": 0.05, "y": 0.05, "w": 0.90, "h": 0.90 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000205.webp",
+              "visual_metadata": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "revision_id": "019e8a3c-7b2d-7000-8001-000000000010",
+      "revision_number": 1,
+      "status": "READY",
+      "captured_at": "2026-03-26T18:45:00Z",
+      "pages": [
+        {
+          "page_id": "019e8a3c-7b2d-7000-8001-000000000104",
+          "page_order": 4,
+          "photo_url": "s3://revisemieux/chapters/019e8a3c-7b2d-7000-8001-000000000001/revisions/019e8a3c-7b2d-7000-8001-000000000010/pages/4.webp",
+          "ocr_status": "DONE",
+          "ocr_confidence": 0.87,
+          "text_fingerprint": "sha256:d4e5f6a1b2c3",
+          "blocks": [
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000206",
+              "block_type": "TEXT",
+              "ocr_text": "V. Expérience : mise en évidence de la photosynthèse\n\nProtocole :\n1. Prendre deux plantes aquatiques (élodées) dans deux béchers\n2. Placer le bécher A à la lumière et le bécher B dans l'obscurité\n3. Ajouter du bleu de bromothymol (indicateur de CO₂) dans chaque bécher\n4. Attendre 2 heures\n5. Observer la couleur du bleu de bromothymol\n\nRésultats attendus :\n- Bécher A (lumière) : le bleu de bromothymol devient bleu (le CO₂ a été consommé)\n- Bécher B (obscurité) : le bleu de bromothymol reste jaune/vert (pas de photosynthèse)",
+              "confidence": 0.86,
+              "bbox": { "x": 0.05, "y": 0.05, "w": 0.90, "h": 0.55 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000206.webp",
+              "visual_metadata": null
+            },
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000207",
+              "block_type": "TABLE",
+              "ocr_text": "Bécher A (lumière) | Bécher B (obscurité)\nCouleur initiale : jaune/vert | Couleur initiale : jaune/vert\nCouleur finale : bleu | Couleur finale : jaune/vert\nConclusion : CO₂ consommé | Conclusion : pas de photosynthèse",
+              "confidence": 0.78,
+              "bbox": { "x": 0.10, "y": 0.60, "w": 0.80, "h": 0.35 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000207.webp",
+              "visual_metadata": {
+                "visual_type": "table",
+                "labels": [],
+                "caption": "Tableau de résultats de l'expérience du bleu de bromothymol",
+                "alt_text": null,
+                "table_structure": {
+                  "rows": 4,
+                  "cols": 2,
+                  "headers": ["Bécher A (lumière)", "Bécher B (obscurité)"],
+                  "cells": [
+                    ["Couleur initiale : jaune/vert", "Couleur initiale : jaune/vert"],
+                    ["Couleur finale : bleu", "Couleur finale : jaune/vert"],
+                    ["CO₂ consommé", "Pas de photosynthèse"]
+                  ]
+                },
+                "axis_labels": null
+              }
+            }
+          ]
+        },
+        {
+          "page_id": "019e8a3c-7b2d-7000-8001-000000000105",
+          "page_order": 5,
+          "photo_url": "s3://revisemieux/chapters/019e8a3c-7b2d-7000-8001-000000000001/revisions/019e8a3c-7b2d-7000-8001-000000000010/pages/5.webp",
+          "ocr_status": "DONE",
+          "ocr_confidence": 0.84,
+          "text_fingerprint": "sha256:e5f6a1b2c3d4",
+          "blocks": [
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000208",
+              "block_type": "TEXT",
+              "ocr_text": "VI. Facteurs influençant la photosynthèse\n\n1. La lumière : plus l'intensité lumineuse est forte, plus la photosynthèse est active (jusqu'à un seuil de saturation)\n2. La température : la photosynthèse est optimale entre 25°C et 35°C. Au-delà de 40°C, les enzymes sont dénaturées.\n3. La concentration en CO₂ : plus il y a de CO₂, plus la photosynthèse est active (facteur limitant)\n4. L'eau : indispensable comme réactif de la photosynthèse\n\nConclusion : la photosynthèse est un processus vital pour les écosystèmes. Elle produit l'O₂ que nous respirons et constitue la base des chaînes alimentaires.",
+              "confidence": 0.90,
+              "bbox": { "x": 0.05, "y": 0.05, "w": 0.90, "h": 0.90 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000208.webp",
+              "visual_metadata": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "revision_id": "019e8a3c-7b2d-7000-8001-000000000010",
+      "revision_number": 1,
+      "status": "READY",
+      "captured_at": "2026-03-28T19:15:00Z",
+      "pages": [
+        {
+          "page_id": "019e8a3c-7b2d-7000-8001-000000000106",
+          "page_order": 6,
+          "photo_url": "s3://revisemieux/chapters/019e8a3c-7b2d-7000-8001-000000000001/revisions/019e8a3c-7b2d-7000-8001-000000000010/pages/6.webp",
+          "ocr_status": "DONE",
+          "ocr_confidence": 0.86,
+          "text_fingerprint": "sha256:f6a1b2c3d4e5",
+          "blocks": [
+            {
+              "block_id": "019e8a3c-7b2d-7000-8001-000000000209",
+              "block_type": "TEXT",
+              "ocr_text": "Correction exercice 3 — La photosynthèse\n\n1. L'équation bilan de la photosynthèse est :\n   6 CO₂ + 6 H₂O → C₆H₁₂O₆ + 6 O₂ (en présence de lumière)\n\n2. Les chloroplastes sont les organites où se déroule la photosynthèse. Ils contiennent la chlorophylle.\n\n3. La plante à la lumière produit de l'O₂ car elle fait la photosynthèse. La plante dans l'obscurité ne produit pas d'O₂ car la photosynthèse nécessite de la lumière.\n\n4. Les stomates sont des orifices situés sur la face inférieure des feuilles. Ils permettent l'entrée du CO₂ et la sortie de l'O₂.\n\n5. Un organisme autotrophe fabrique sa propre matière organique à partir de matière minérale. Un organisme hétérotrophe doit consommer d'autres êtres vivants.",
+              "confidence": 0.88,
+              "bbox": { "x": 0.05, "y": 0.05, "w": 0.90, "h": 0.90 },
+              "crop_url": "s3://revisemieux/crops/019e8a3c-7b2d-7000-8001-000000000209.webp",
+              "visual_metadata": null
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "notions": [
+    {
+      "notion_id": "019e8a3c-7b2d-7000-8001-000000000301",
+      "name": "Définition et principe de la photosynthèse",
+      "concept_tags": ["photosynthese", "definition", "autotrophe", "heterotrophe"],
+      "sort_order": 1,
+      "items": [
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000401",
+          "item_type": "KNOWLEDGE",
+          "term": "Photosynthèse",
+          "keywords": ["processus", "plantes vertes", "lumière", "CO₂", "H₂O", "glucose", "O₂", "matière organique"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.92,
+          "fidelity_score": 0.95,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "photosynthese|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "enriched",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000101",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000201"]
+            },
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000103",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000205"]
+            },
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000106",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000209"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-28T19:20:00Z"
+        },
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000402",
+          "item_type": "KNOWLEDGE",
+          "term": "Autotrophe",
+          "keywords": ["organisme", "matière organique", "matière minérale", "plantes"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.91,
+          "fidelity_score": 0.93,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "autotrophe|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "enriched",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000103",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000205"]
+            },
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000106",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000209"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-28T19:20:00Z"
+        },
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000403",
+          "item_type": "KNOWLEDGE",
+          "term": "Hétérotrophe",
+          "keywords": ["organisme", "consommer", "êtres vivants", "animaux"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.91,
+          "fidelity_score": 0.92,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "heterotrophe|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "original",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000103",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000205"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-24T18:35:00Z"
+        }
+      ]
+    },
+    {
+      "notion_id": "019e8a3c-7b2d-7000-8001-000000000302",
+      "name": "Chloroplastes et chlorophylle",
+      "concept_tags": ["chloroplaste", "chlorophylle", "stomate", "organite"],
+      "sort_order": 2,
+      "items": [
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000404",
+          "item_type": "KNOWLEDGE",
+          "term": "Chloroplaste",
+          "keywords": ["organite", "cellule végétale", "chlorophylle", "photosynthèse"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.90,
+          "fidelity_score": 0.94,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "chloroplaste|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "enriched",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000101",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000201", "019e8a3c-7b2d-7000-8001-000000000202"]
+            },
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000106",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000209"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-28T19:20:00Z"
+        },
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000405",
+          "item_type": "KNOWLEDGE",
+          "term": "Chlorophylle",
+          "keywords": ["pigment", "vert", "lumière", "captation"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.89,
+          "fidelity_score": 0.91,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "chlorophylle|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "original",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000101",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000201", "019e8a3c-7b2d-7000-8001-000000000202"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-24T18:35:00Z"
+        },
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000406",
+          "item_type": "KNOWLEDGE",
+          "term": "Stomate",
+          "keywords": ["orifice", "feuille", "échanges gazeux", "CO₂", "O₂", "face inférieure"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.89,
+          "fidelity_score": 0.90,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "stomate|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "enriched",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000101",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000202"]
+            },
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000106",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000209"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-28T19:20:00Z"
+        },
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000407",
+          "item_type": "DOCUMENT",
+          "term": "Schéma bilan de la photosynthèse",
+          "keywords": ["schéma", "bilan", "feuille", "chloroplaste", "CO₂", "H₂O", "O₂", "glucose"],
+          "steps": [],
+          "tags": ["schema"],
+          "confidence": 0.82,
+          "fidelity_score": 0.88,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "schema bilan de la photosynthese|DOCUMENT|SVT-PHOTO",
+          "merge_status": "original",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000102",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000203"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-24T18:35:00Z"
+        }
+      ]
+    },
+    {
+      "notion_id": "019e8a3c-7b2d-7000-8001-000000000303",
+      "name": "Équation bilan de la photosynthèse",
+      "concept_tags": ["equation", "bilan", "CO2", "H2O", "glucose", "O2"],
+      "sort_order": 3,
+      "items": [
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000408",
+          "item_type": "KNOWLEDGE",
+          "term": "Équation bilan de la photosynthèse",
+          "keywords": ["6 CO₂", "6 H₂O", "C₆H₁₂O₆", "6 O₂", "lumière"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.88,
+          "fidelity_score": 0.96,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "equation bilan de la photosynthese|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "enriched",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000102",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000204"]
+            },
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000106",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000209"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-24T18:35:00Z",
+          "updated_at": "2026-03-28T19:20:00Z"
+        }
+      ]
+    },
+    {
+      "notion_id": "019e8a3c-7b2d-7000-8001-000000000304",
+      "name": "Expérience du bleu de bromothymol",
+      "concept_tags": ["experience", "bromothymol", "elodee", "lumiere", "obscurite"],
+      "sort_order": 4,
+      "items": [
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000409",
+          "item_type": "PROCEDURE",
+          "term": "Expérience du bleu de bromothymol",
+          "keywords": ["élodée", "bécher", "lumière", "obscurité", "bleu de bromothymol", "CO₂"],
+          "steps": [
+            { "step_order": 1, "content": "Prendre deux plantes aquatiques (élodées) dans deux béchers" },
+            { "step_order": 2, "content": "Placer le bécher A à la lumière et le bécher B dans l'obscurité" },
+            { "step_order": 3, "content": "Ajouter du bleu de bromothymol dans chaque bécher" },
+            { "step_order": 4, "content": "Attendre 2 heures" },
+            { "step_order": 5, "content": "Observer la couleur du bleu de bromothymol" }
+          ],
+          "tags": [],
+          "confidence": 0.86,
+          "fidelity_score": 0.89,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "experience du bleu de bromothymol|PROCEDURE|SVT-PHOTO",
+          "merge_status": "original",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000104",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000206"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-26T18:50:00Z",
+          "updated_at": "2026-03-26T18:50:00Z"
+        },
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000410",
+          "item_type": "DOCUMENT",
+          "term": "Tableau de résultats — bleu de bromothymol",
+          "keywords": ["tableau", "résultats", "bécher A", "bécher B", "couleur", "bleu", "jaune"],
+          "steps": [],
+          "tags": ["table"],
+          "confidence": 0.78,
+          "fidelity_score": 0.85,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "tableau de resultats — bleu de bromothymol|DOCUMENT|SVT-PHOTO",
+          "merge_status": "original",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000104",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000207"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-26T18:50:00Z",
+          "updated_at": "2026-03-26T18:50:00Z"
+        }
+      ]
+    },
+    {
+      "notion_id": "019e8a3c-7b2d-7000-8001-000000000305",
+      "name": "Facteurs influençant la photosynthèse",
+      "concept_tags": ["facteurs", "lumiere", "temperature", "CO2", "eau", "saturation"],
+      "sort_order": 5,
+      "items": [
+        {
+          "item_id": "019e8a3c-7b2d-7000-8001-000000000411",
+          "item_type": "KNOWLEDGE",
+          "term": "Facteurs influençant la photosynthèse",
+          "keywords": ["lumière", "température", "CO₂", "eau", "seuil de saturation", "25-35°C", "enzymes"],
+          "steps": [],
+          "tags": [],
+          "confidence": 0.90,
+          "fidelity_score": 0.93,
+          "fidelity_flag": null,
+          "validation_required": false,
+          "archived": false,
+          "canonical_key": "facteurs influencant la photosynthese|KNOWLEDGE|SVT-PHOTO",
+          "merge_status": "original",
+          "replaced_by_id": null,
+          "source_refs": [
+            {
+              "page_id": "019e8a3c-7b2d-7000-8001-000000000105",
+              "block_ids": ["019e8a3c-7b2d-7000-8001-000000000208"]
+            }
+          ],
+          "llm_model_version": "mistral-small-2503",
+          "prompt_template_version": "v1.0.0",
+          "created_at": "2026-03-26T18:50:00Z",
+          "updated_at": "2026-03-26T18:50:00Z"
+        }
+      ]
+    }
+  ],
+  "merge_log": [
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000501",
+      "action": "append",
+      "source_item_id": "019e8a3c-7b2d-7000-8001-000000000409",
+      "target_item_id": null,
+      "reason": "New concept: 'Expérience du bleu de bromothymol' not found in existing items. CanonicalKey miss + Jaccard < 0.5.",
+      "confidence": 0.86,
+      "created_at": "2026-03-26T18:50:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000502",
+      "action": "append",
+      "source_item_id": "019e8a3c-7b2d-7000-8001-000000000410",
+      "target_item_id": null,
+      "reason": "New concept: 'Tableau de résultats — bleu de bromothymol' (DOCUMENT type, table visual block).",
+      "confidence": 0.78,
+      "created_at": "2026-03-26T18:50:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000503",
+      "action": "append",
+      "source_item_id": "019e8a3c-7b2d-7000-8001-000000000411",
+      "target_item_id": null,
+      "reason": "New concept: 'Facteurs influençant la photosynthèse'. No matching canonical key.",
+      "confidence": 0.90,
+      "created_at": "2026-03-26T18:50:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000504",
+      "action": "enrich",
+      "source_item_id": null,
+      "target_item_id": "019e8a3c-7b2d-7000-8001-000000000401",
+      "reason": "Session 3 correction exercise confirmed definition of photosynthèse. Added source_ref from page 6. No new keywords, but cross-validation increases confidence.",
+      "confidence": 0.92,
+      "created_at": "2026-03-28T19:20:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000505",
+      "action": "enrich",
+      "source_item_id": null,
+      "target_item_id": "019e8a3c-7b2d-7000-8001-000000000404",
+      "reason": "Correction exercise (page 6) confirms chloroplaste definition. Added source_ref. Confidence maintained.",
+      "confidence": 0.90,
+      "created_at": "2026-03-28T19:20:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000506",
+      "action": "enrich",
+      "source_item_id": null,
+      "target_item_id": "019e8a3c-7b2d-7000-8001-000000000406",
+      "reason": "Correction exercise enriches stomate definition with 'face inférieure des feuilles'. New keyword added.",
+      "confidence": 0.89,
+      "created_at": "2026-03-28T19:20:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000507",
+      "action": "enrich",
+      "source_item_id": null,
+      "target_item_id": "019e8a3c-7b2d-7000-8001-000000000402",
+      "reason": "Correction exercise provides clearer definition of autotrophe: 'fabrique sa propre matière organique à partir de matière minérale'. Keywords enriched.",
+      "confidence": 0.91,
+      "created_at": "2026-03-28T19:20:00Z"
+    },
+    {
+      "id": "019e8a3c-7b2d-7000-8001-000000000508",
+      "action": "enrich",
+      "source_item_id": null,
+      "target_item_id": "019e8a3c-7b2d-7000-8001-000000000408",
+      "reason": "Correction exercise confirms equation bilan. Cross-validated with page 2 extraction. Fidelity score increased.",
+      "confidence": 0.88,
+      "created_at": "2026-03-28T19:20:00Z"
+    }
+  ]
+}

--- a/docs/architecture/pivot-format-schema.json
+++ b/docs/architecture/pivot-format-schema.json
@@ -1,0 +1,416 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://revisemieux.fr/schemas/pivot-document-v1.json",
+  "title": "PivotDocument",
+  "description": "Canonical representation of a chapter's extracted content. This is a projection of the SQL tables (chapters, chapter_revisions, pages, blocks, items, notions) assembled for debugging, export, and LLM context injection. Not stored as a single document in the database.",
+  "type": "object",
+  "required": ["metadata", "capture_sessions", "notions"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["chapter_id", "subject", "class_level", "title", "pivot_version", "updated_at"],
+      "properties": {
+        "chapter_id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUIDv7 of the Chapter aggregate root."
+        },
+        "user_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "subject": {
+          "type": "string",
+          "description": "School subject (e.g., 'SVT', 'Physique-Chimie', 'Histoire-Géographie')."
+        },
+        "class_level": {
+          "type": "string",
+          "description": "Grade level (e.g., '5ème', '4ème', '3ème')."
+        },
+        "title": {
+          "type": "string",
+          "description": "Chapter title as extracted or assigned by the student."
+        },
+        "pack_id": {
+          "type": ["string", "null"],
+          "description": "Optional pack identifier (e.g., 'SVT-PHOTO')."
+        },
+        "pivot_version": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Incremented on every merge operation. Version 1 = initial pipeline."
+        },
+        "current_revision_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "capture_sessions": {
+      "type": "array",
+      "description": "Ordered list of capture sessions (revisions). Each session represents a batch of pages uploaded together. This layer is IMMUTABLE after creation.",
+      "items": {
+        "type": "object",
+        "required": ["revision_id", "revision_number", "status", "captured_at", "pages"],
+        "properties": {
+          "revision_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "revision_number": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": ["PROCESSING", "READY", "PARTIAL", "FAILED", "PROCESSING_INCREMENTAL"]
+          },
+          "captured_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/Page"
+            }
+          }
+        }
+      }
+    },
+    "notions": {
+      "type": "array",
+      "description": "Structured pedagogical content organized by Notion. This layer is MUTABLE and enriched incrementally.",
+      "items": {
+        "$ref": "#/$defs/Notion"
+      }
+    },
+    "merge_log": {
+      "type": "array",
+      "description": "Audit trail of all merge operations performed on this chapter.",
+      "items": {
+        "$ref": "#/$defs/MergeLogEntry"
+      }
+    }
+  },
+  "$defs": {
+    "Page": {
+      "type": "object",
+      "required": ["page_id", "page_order", "photo_url", "ocr_status"],
+      "properties": {
+        "page_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "page_order": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "photo_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "ocr_status": {
+          "type": "string",
+          "enum": ["UPLOADING", "OCR_PENDING", "OCR_PROCESSING", "PROCESSED", "ITEMS_GENERATING", "DONE", "NO_ITEMS", "ITEMS_FAILED", "FAILED", "BLURRY"]
+        },
+        "ocr_confidence": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Global OCR confidence for this page. < 0.3 triggers BLURRY status (Z2-AC03)."
+        },
+        "text_fingerprint": {
+          "type": ["string", "null"],
+          "description": "Hash of OCR text for quick similarity detection (re-photograph detection)."
+        },
+        "blocks": {
+          "type": "array",
+          "description": "IMMUTABLE OCR observations. Never modified after creation.",
+          "items": {
+            "$ref": "#/$defs/Block"
+          }
+        }
+      }
+    },
+    "Block": {
+      "type": "object",
+      "required": ["block_id", "block_type", "confidence"],
+      "properties": {
+        "block_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "block_type": {
+          "type": "string",
+          "enum": ["TEXT", "PHOTO", "SCHEMA", "MAP", "GRAPH", "TABLE", "CIRCUIT", "DECORATIVE"]
+        },
+        "ocr_text": {
+          "type": ["string", "null"],
+          "description": "Raw OCR text extraction. Null for visual-only blocks."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "bbox": {
+          "$ref": "#/$defs/BBox"
+        },
+        "crop_url": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "visual_metadata": {
+          "type": ["object", "null"],
+          "description": "Additional metadata for visual blocks (SCHEMA, MAP, GRAPH, TABLE, CIRCUIT, PHOTO).",
+          "properties": {
+            "visual_type": {
+              "type": "string",
+              "enum": ["diagram", "graph", "table", "figure", "map", "circuit", "photo"]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string" },
+                  "position": { "$ref": "#/$defs/Point" }
+                },
+                "required": ["text"]
+              }
+            },
+            "caption": {
+              "type": ["string", "null"]
+            },
+            "alt_text": {
+              "type": ["string", "null"]
+            },
+            "table_structure": {
+              "type": ["object", "null"],
+              "properties": {
+                "rows": { "type": "integer" },
+                "cols": { "type": "integer" },
+                "headers": {
+                  "type": ["array", "null"],
+                  "items": { "type": "string" }
+                },
+                "cells": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                }
+              },
+              "required": ["rows", "cols", "cells"]
+            },
+            "axis_labels": {
+              "type": ["object", "null"],
+              "properties": {
+                "x_label": { "type": "string" },
+                "y_label": { "type": "string" },
+                "x_unit": { "type": ["string", "null"] },
+                "y_unit": { "type": ["string", "null"] }
+              }
+            }
+          }
+        }
+      }
+    },
+    "BBox": {
+      "type": "object",
+      "required": ["x", "y", "w", "h"],
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "w": { "type": "number" },
+        "h": { "type": "number" }
+      }
+    },
+    "Point": {
+      "type": "object",
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    },
+    "Notion": {
+      "type": "object",
+      "required": ["notion_id", "name", "sort_order", "items"],
+      "properties": {
+        "notion_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable notion name generated by the LLM (Z7-AC15)."
+        },
+        "concept_tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "sort_order": {
+          "type": "integer"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Item"
+          }
+        }
+      }
+    },
+    "Item": {
+      "type": "object",
+      "required": ["item_id", "item_type", "confidence", "source_refs", "merge_status"],
+      "properties": {
+        "item_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "item_type": {
+          "type": "string",
+          "enum": ["KNOWLEDGE", "PROCEDURE", "DOCUMENT", "WRITING"]
+        },
+        "term": {
+          "type": ["string", "null"],
+          "description": "Main term/concept of the item."
+        },
+        "keywords": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "steps": {
+          "type": "array",
+          "description": "Ordered steps for PROCEDURE items.",
+          "items": {
+            "type": "object",
+            "required": ["step_order", "content"],
+            "properties": {
+              "step_order": { "type": "integer" },
+              "content": { "type": "string" }
+            }
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "fidelity_score": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Result of fidelity check (Z3-AC10). Null if not yet checked."
+        },
+        "fidelity_flag": {
+          "type": ["string", "null"],
+          "enum": [null, "low", "medium"]
+        },
+        "validation_required": {
+          "type": "boolean"
+        },
+        "archived": {
+          "type": "boolean"
+        },
+        "canonical_key": {
+          "type": ["string", "null"],
+          "description": "Normalized identity key: lowercase(term)|item_type|pack_id. Used for deduplication."
+        },
+        "merge_status": {
+          "type": "string",
+          "enum": ["original", "enriched", "replaced", "conflict", "alternative"],
+          "description": "Tracks how this item was produced: original (first pipeline), enriched (incremental add), replaced (better extraction), conflict (contradiction detected), alternative (pending HITL review)."
+        },
+        "replaced_by_id": {
+          "type": ["string", "null"],
+          "format": "uuid",
+          "description": "If this item was replaced, points to the replacement item."
+        },
+        "source_refs": {
+          "type": "array",
+          "description": "Traceability: which pages and blocks produced this item.",
+          "items": {
+            "type": "object",
+            "required": ["page_id"],
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "block_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        },
+        "llm_model_version": {
+          "type": ["string", "null"]
+        },
+        "prompt_template_version": {
+          "type": ["string", "null"]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "MergeLogEntry": {
+      "type": "object",
+      "required": ["id", "action", "reason", "created_at"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["append", "enrich", "replace", "archive_dup", "flag_conflict", "create_alt"]
+        },
+        "source_item_id": {
+          "type": ["string", "null"],
+          "format": "uuid",
+          "description": "The new/incoming item that triggered this action."
+        },
+        "target_item_id": {
+          "type": ["string", "null"],
+          "format": "uuid",
+          "description": "The existing item affected by this action."
+        },
+        "reason": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": ["number", "null"]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Architecture complète du pipeline OCR/IDP incrémental pour l'ingestion progressive de photos de cahier
- Format pivot canonique (JSON Schema) entre OCR et LLM avec traçabilité source
- Workflow de merge incrémental en 10 étapes avec diagrammes Mermaid
- Tableau de décision merge avec 7 règles et seuils concrets (Jaccard, confidence delta)
- Impact sur les Mastery existants (transfert, gel, split)
- Signatures Go des méthodes domaine (MergeEngine, domain events, ports LLM étendus)
- Migrations SQL pour le support du merge incrémental

## Livrables

| Fichier | Contenu |
|---------|---------|
| `docs/architecture/ocr-idp-incremental.md` | Document d'architecture complet (15 sections) |
| `docs/architecture/pivot-format-schema.json` | JSON Schema du format pivot |
| `docs/architecture/pivot-format-example-photosynthese.json` | Exemple concret "La photosynthèse" avec 3 sessions de capture |
| `docs/architecture/merge-decision-table.md` | Tableau de décision merge avec seuils et cas limites |

## Questions ouvertes pour le Product Owner

1. **Seuil Jaccard pour doublons (0.85)** -- est-ce trop strict ? Un seuil plus bas (0.75) détecterait plus de doublons mais risquerait de fusionner des items distincts. À valider sur les 4 chapitres pilotes du Lot 0.

2. **Transfert de Mastery sur archive doublon** -- quand on archive un doublon et qu'on transfère le Mastery vers le survivant, faut-il prendre le Mastery le plus avancé ou le plus récent ? Le document propose le plus avancé (SOLID > OK > FRAGILE > UNKNOWN).

3. **MVP sans merge** -- le document recommande de ne pas implémenter le merge pour le Lot 0 (re-processing complet). Est-ce acceptable sachant que les Mastery seront reset à chaque ajout de page ? Pour 4 chapitres pilotes, le coût est faible.

4. **CoherenceChecker LLM** -- appeler un LLM pour détecter les contradictions ajoute du coût et de la latence. Pour le Lot 0, est-ce qu'un simple matching par CanonicalKey + Jaccard suffit (sans LLM) ?

5. **Correction d'exercice** -- le document traite les pages de correction comme des enrichissements (ENRICH). Faut-il un tag `is_correction` sur les pages/items pour distinguer le cours de la correction dans l'UI ?

## Test plan

- [ ] Vérifier que le JSON Schema est valide (`jsonschema` CLI)
- [ ] Vérifier que l'exemple photosynthèse est conforme au schema
- [ ] Review des signatures Go pour compatibilité avec le code existant dans `domain/chapter/`
- [ ] Review de la migration SQL 003 pour compatibilité avec 001_initial_schema.sql
- [ ] Valider les seuils de merge sur les données du benchmark `10_SVT_cours_louis`

🤖 Generated with [Claude Code](https://claude.com/claude-code)