### PR TITLE
docs: user flow complet eleve + parent

### DIFF
--- a/docs/ux/edge-cases.md
+++ b/docs/ux/edge-cases.md
@@ -1,0 +1,327 @@
+# Edge cases -- Revise Mieux
+
+> Catalogue exhaustif des edge cases classes par domaine. Chaque entree couvre : risque UX, traitement ideal, copy/guidance, et chemin de recuperation.
+
+---
+
+## 1. Capture photo
+
+### EC-01 : Photo floue
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve ne se rend pas compte que la photo est mauvaise. Le pipeline echoue plus tard, frustration differee. |
+| **Traitement ideal** | Detection cote client avant upload : si le blur score depasse un seuil, message d'avertissement AVANT envoi. |
+| **Copy** | "Cette photo semble un peu floue. Reprends-la avec un meilleur eclairage pour de meilleurs resultats." |
+| **Recovery** | L'eleve peut reprendre la photo ou continuer malgre tout. Le pipeline traite quand meme avec confidence reduite (Z2-AC03). |
+| **AC** | Z2-AC03 |
+
+### EC-02 : Photo de travers / mal cadree
+
+| | |
+|---|---|
+| **Risque UX** | Texte tronque, OCR partiel. L'eleve ne voit pas le probleme. |
+| **Traitement ideal** | Proposition de recadrage automatique (crop suggestion) avant validation de la page. |
+| **Copy** | "La page semble coupee sur le bord droit. Veux-tu recadrer ou reprendre ?" |
+| **Recovery** | Option recadrage OU reprendre la photo OU ignorer et continuer. |
+| **AC** | -- (non couvert par AC existant, recommandation nouvelle) |
+
+### EC-03 : Plusieurs pages en une seule photo
+
+| | |
+|---|---|
+| **Risque UX** | Double page = texte trop petit, OCR degrade. L'eleve pense avoir fait 2 pages en 1. |
+| **Traitement ideal** | Detection (ratio hauteur/largeur atypique) + avertissement. |
+| **Copy** | "On dirait que tu as photographie 2 pages en meme temps. Pour de meilleurs resultats, photographie une page a la fois." |
+| **Recovery** | Reprendre en 2 photos separees OU continuer (traitement best-effort). |
+| **AC** | -- (recommandation nouvelle) |
+
+### EC-04 : Pas de connexion pendant la capture
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve prend ses photos dans le bus sans wifi. L'upload echoue. |
+| **Traitement ideal** | Stockage local des photos. Upload automatique au retour de la connexion. |
+| **Copy** | "Photos enregistrees ! Elles seront analysees des que tu auras du reseau." |
+| **Recovery** | Indicateur "X photos en attente d'envoi" sur le dashboard. Upload en background. |
+| **AC** | Z6-AC31 (resilience reseau) |
+
+### EC-05 : Pipeline J0 timeout ou echec complet
+
+| | |
+|---|---|
+| **Risque UX** | Premier upload = moment de verite. Un echec ici = "ca marche pas" = desinstallation. |
+| **Traitement ideal** | Ecran de recovery empathique (Z8-AC03) avec conseils visuels + fallback chapitre demo. |
+| **Copy** | "Les photos sont un peu difficiles a lire. Pas de panique, ca arrive souvent au debut !" |
+| **Recovery** | 3 chemins : reprendre les photos / essayer quand meme (si items partiels) / chapitre demo. |
+| **AC** | Z8-AC03, Z2-AC07 |
+
+### EC-06 : Photo contenant du contenu de plusieurs chapitres
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve a deux cours sur la meme double page. Le pipeline attribue tout a un seul chapitre. |
+| **Traitement ideal** | Detection LLM (changement de sujet dans le texte) + question de clarification. |
+| **Copy** | "On a detecte du contenu sur 2 sujets differents. A quel chapitre ces notes appartiennent-elles ?" |
+| **Recovery** | Choix du chapitre OU creation automatique de 2 chapitres distincts. |
+| **AC** | -- (non couvert, recommandation future) |
+
+---
+
+## 2. Session de revision
+
+### EC-07 : L'eleve ferme l'app en pleine session
+
+| | |
+|---|---|
+| **Risque UX** | Perte de progression. L'eleve ne sait pas si ses reponses ont ete enregistrees. |
+| **Traitement ideal** | Persistance du current_question_index en base. Reprise automatique a la reouverture. |
+| **Copy** | (a la reouverture) "Tu avais une session en cours. On reprend ou tu en etais ?" |
+| **Recovery** | Reprise a la question N+1. Les masteries des questions 1-N sont deja mises a jour. TTL 72h. |
+| **AC** | Z4-AC04 |
+
+### EC-08 : Pas assez d'items pour composer une session
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve appuie sur "Lancer une session" et... rien. Frustration. |
+| **Traitement ideal** | Session viable sur petit chapitre (min 4 questions meme avec 3 items). Reformulations. |
+| **Copy** | "Petite session rapide -- [N] questions sur ce chapitre" |
+| **Recovery** | Session courte 3-5 min avec reformulations (meme item, gabarits/distractors differents). |
+| **AC** | Z4-AC11 |
+
+### EC-09 : Tous les items sont SOLID
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve ouvre l'app, rien a faire. "Cette app ne sert plus a rien." |
+| **Traitement ideal** | Message positif + session de consolidation optionnelle sans risque de regression. |
+| **Copy** | "Bravo -- tu es a jour sur tous tes chapitres ! Prochaine revision prevue [date]. Session de consolidation ?" |
+| **Recovery** | Bouton optionnel "Session de consolidation" (5 questions, aucune regression possible). |
+| **AC** | Z4-AC13 |
+
+### EC-10 : Reponse ambigue (scoring au seuil de 0.7)
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve pense avoir bien repondu, le systeme dit "echec". Sentiment d'injustice. |
+| **Traitement ideal** | Scoring graduel (Z1-AC23) avec feedback nuance. Score partiel visible. |
+| **Copy** | "Reponse partiellement correcte. Il te manquait [element]. Score : 0.6 -- pas loin !" |
+| **Recovery** | Demi-succes ne penalise pas la maitrise autant qu'un echec total. |
+| **AC** | Z1-AC23, Z1-AC24 |
+
+### EC-11 : Quiz trop difficile (3 echecs consecutifs)
+
+| | |
+|---|---|
+| **Risque UX** | Cascade d'echecs = "je suis nul" = fermeture de l'app. Critique pour Ines (anxieuse). |
+| **Traitement ideal** | Descente automatique de difficulte apres 3 echecs. Retour aux gabarits simples. |
+| **Copy** | "On revoit les bases ensemble -- c'est normal de ne pas tout retenir du premier coup !" |
+| **Recovery** | Difficulte reduite pour les 2 questions suivantes. Renvoi vers la carte de lecon. Pause J+2 apres 5 echecs. |
+| **AC** | Z1-AC19 |
+
+### EC-12 : Quiz trop facile (> 92% de reussite)
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve s'ennuie. "C'est pour les bebes." Critique pour Lucas (desengage). |
+| **Traitement ideal** | Montee en difficulte invisible (Z4-AC16). Gabarits plus exigeants sans message. |
+| **Copy** | (aucun message -- la montee est silencieuse pour ne pas creer de pression) |
+| **Recovery** | Le systeme ajuste automatiquement, l'eleve sent que les questions deviennent "plus interessantes". |
+| **AC** | Z4-AC16 |
+
+### EC-13 : Reponses trop rapides (anti-clicking aveugle)
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve (Lucas) clique au hasard pour finir vite. Progression fictive. |
+| **Traitement ideal** | Reponses rapides correctes ne comptent pas pour la progression. Reponses incorrectes penalisent normalement. |
+| **Copy** | (apres 3 reponses rapides correctes) "Prends ton temps pour bien lire les questions -- tes reponses rapides ne comptent pas pour ta progression." |
+| **Recovery** | L'eleve peut continuer mais les items seront re-proposes. Pas de blocage UX. |
+| **AC** | Z3-AC15 |
+
+---
+
+## 3. Validation HITL
+
+### EC-14 : Le parent n'a jamais valide
+
+| | |
+|---|---|
+| **Risque UX** | Items bloques en gabarits simples indefiniment. Maitrise plafonnee. |
+| **Traitement ideal** | Bandeau non-bloquant sur le chapitre. Max 3 tasks/semaine pour le parent. Le chapitre reste utilisable. |
+| **Copy** | "6 zones a verifier -- vos exercices seront plus precis apres verification." |
+| **Recovery** | L'eleve peut tout ignorer et continuer. Admin en fallback. Le diagnostic fonctionne malgre tout. |
+| **AC** | Z3-AC06, Z3-AC08 |
+
+### EC-15 : Item rejete (correction) par le parent
+
+| | |
+|---|---|
+| **Risque UX** | L'item corrige invalide le cache des questions. L'eleve voit un changement inexplique. |
+| **Traitement ideal** | Cache invalidation ciblee (uniquement les questions de l'item corrige). Regeneration lazy. |
+| **Copy** | (pas de message visible cote eleve -- la correction est transparente) |
+| **Recovery** | Les prochaines questions sur cet item utiliseront le contenu corrige. Transition fluide. |
+| **AC** | Z3-AC03, Z3-AC07 |
+
+### EC-16 : Parent ne comprend pas un item
+
+| | |
+|---|---|
+| **Risque UX** | Le parent confirme un item faux par defaut. Pire cas : l'eleve etudie du contenu incorrect. |
+| **Traitement ideal** | Option "Je ne sais pas" qui delegue a l'admin. Retractation possible si signalement ulterieur. |
+| **Copy** | Bouton "Je ne sais pas" + "L'item sera verifie par notre equipe." |
+| **Recovery** | Admin review. Si l'item a ete confirme par erreur, le signalement eleve (Z3-AC12) ou l'anomalie (Z3-AC13) le detectent. Retractation Z3-AC14. |
+| **AC** | Z3-AC04, Z3-AC14 |
+
+### EC-17 : Ado qui clique "Ignorer" sur tout
+
+| | |
+|---|---|
+| **Risque UX** | Tous les items incertains disparaissent du circuit pedagogique. Lacunes invisibles. |
+| **Traitement ideal** | Section "Points non verifies" visible dans la carte lecon. Nudge discret. Bouton "Reactiver". |
+| **Copy** | "4 points n'ont pas ete verifies -- ils ne seront pas dans tes exercices." + "Tout laisser ignore" si choix delibere. |
+| **Recovery** | L'eleve peut reactiver a tout moment. L'admin traite en backoffice. |
+| **AC** | Z3-AC05, Z3-AC16 |
+
+---
+
+## 4. Adoption et engagement
+
+### EC-18 : Eleve abandonne en plein flow
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve quitte pendant le pipeline, pendant une session, pendant la validation. Etat incoherent. |
+| **Traitement ideal** | Chaque etape est interruptible et reprenante. Aucun etat incoherent possible. |
+| **Copy** | (a la reouverture) Message contextuel adapte : "Ton cours est en cours d'analyse" / "Tu avais une session en cours" |
+| **Recovery** | Pipeline continue en background. Session reprend au dernier point (Z4-AC04). Validation reste en file. |
+| **AC** | Z4-AC04, Z8-AC04 |
+
+### EC-19 : Parent ne comprend pas la proposition de valeur
+
+| | |
+|---|---|
+| **Risque UX** | Le parent voit des metriques incomprehensibles. Desinstalle ou ignore. |
+| **Traitement ideal** | Onboarding parent en 3 ecrans (30s). Labels traduits. Digest anticipe a J+2. |
+| **Copy** | Ecran 1 : "Voici ce que fait [Prenom]" (schema visuel simple). Labels : "Pas encore vu", "En cours d'apprentissage", "Compris, a consolider", "Bien acquis". |
+| **Recovery** | Digest anticipe J+2 avec preuves tangibles. Script 3 min pour engagement minimal. |
+| **AC** | Z8-AC05, Z8-AC06, Z6-AC29 |
+
+### EC-20 : L'eleve se sent juge par le scoring
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve (Ines) interprete les regressions comme un jugement. Anxiete et decrochage. |
+| **Traitement ideal** | Growth mindset systematique dans tous les messages. Jamais "echec", toujours "refresh" ou "a revoir". |
+| **Copy** | Regression SOLID->OK : "Ce point a besoin d'un petit refresh -- on le revoit bientot !" (jamais "tu as perdu ta maitrise") |
+| **Recovery** | Le framing positif est applique partout : feedback, debrief, dashboard. Pas de score negatif visible. |
+| **AC** | Z1-AC05, Z1-AC06, Z1-AC26 |
+
+### EC-21 : Aucun contenu exploitable detecte
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve uploade un dessin, une page blanche, ou du texte dans une langue etrangere. 0 items. |
+| **Traitement ideal** | Message empathique + conseils + fallback chapitre demo. |
+| **Copy** | "Aucun contenu n'a pu etre extrait -- verifie la qualite des photos et re-uploade." |
+| **Recovery** | Bouton "Re-uploader", chapitre demo disponible, chapitre cree mais en etat PENDING_UPLOAD. |
+| **AC** | Z2-AC07 |
+
+### EC-22 : Retour apres 5+ jours d'absence
+
+| | |
+|---|---|
+| **Risque UX** | 15 items en retard. Session de 20 min bourrée d'echecs. Decrochage definitif. |
+| **Traitement ideal** | Mode "retour en douceur" : session courte (5 min), gabarits faciles, etalement sur 3-5 jours. |
+| **Copy** | "Content de te revoir ! On reprend doucement avec quelques rappels." |
+| **Recovery** | 4-6 items les plus anciens seulement. Difficulte 1-2. Desactivation auto apres 2 sessions consecutives. |
+| **AC** | Z6-AC22 |
+
+### EC-23 : Retour apres 7+ jours (relance)
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve a completement decroche. La notification de relance est le dernier point de contact. |
+| **Traitement ideal** | 1 seule notification avec deep link vers session courte et facile. Aucune relance supplementaire. |
+| **Copy** | "Tes revisions t'attendent -- [N] points a consolider en [matiere]. On reprend doucement ?" |
+| **Recovery** | Deep link vers session 3-5 min, gabarits faciles. Si ignore, pas de relance jusqu'au prochain evenement contextuel (exam, upload, trimestre). |
+| **AC** | Z6-AC21 |
+
+---
+
+## 5. Connectivite
+
+### EC-24 : Perte de connexion pendant une session
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve repond a une question, la reponse ne part pas. Perte de progression. |
+| **Traitement ideal** | Persistance locale optimiste. Feedback calcule cote client. Sync au retour reseau. |
+| **Copy** | Indicateur discret "synchronisation en cours..." + "Certaines reponses n'ont pas pu etre enregistrees. Elles seront synchronisees a la prochaine connexion." |
+| **Recovery** | Reponses stockees en pending_sync local. FIFO au retour. Mastery mis a jour uniquement a la synchro serveur. |
+| **AC** | Z6-AC31 |
+
+### EC-25 : Perte de connexion pendant un upload
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve a pris 8 photos et l'upload echoue. Il pense que ses photos sont perdues. |
+| **Traitement ideal** | Photos stockees localement. Retry automatique avec indicateur. |
+| **Copy** | "Photos enregistrees ! Elles seront envoyees des que tu auras du reseau." |
+| **Recovery** | Retry automatique (3 tentatives espacees). Indicateur "X photos en attente". L'eleve peut forcer le retry. |
+| **AC** | Z6-AC31 |
+
+### EC-26 : Mode avion prolonge
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve est dans le train ou en zone blanche. Rien ne fonctionne. |
+| **Traitement ideal** | Mode offline partiel : consultation de la carte de lecon (en cache), flashcards statiques. |
+| **Copy** | "Pas de connexion -- tu peux relire ta lecon en attendant." |
+| **Recovery** | Au retour de la connexion, sync automatique de tout ce qui est pending. |
+| **AC** | Z4-AC12 (fallback), Z6-AC31 (resilience) |
+
+---
+
+## 6. Cas limites techniques
+
+### EC-27 : Chapitre avec plus de 30 items
+
+| | |
+|---|---|
+| **Risque UX** | Sessions trop longues. Notions trop nombreuses. Interface surchargee. |
+| **Traitement ideal** | Le pipeline regroupe en 3-7 notions. La session quotidienne reste 10-20 min (selection 70/20/10). |
+| **Copy** | Aucun message special -- l'abstraction par notion masque la complexite. |
+| **Recovery** | L'algorithme de composition gere naturellement les grands chapitres. |
+| **AC** | Z7-AC15 (notions 3-7) |
+
+### EC-28 : Double page identique uploadee
+
+| | |
+|---|---|
+| **Risque UX** | Items en doublon. Confusion dans la carte de lecon. |
+| **Traitement ideal** | Detection de similarite visuelle (> 80%) lors de l'ajout incremental. Avertissement. |
+| **Copy** | "Cette page ressemble a la page 2 deja dans ton chapitre. Ajouter quand meme ?" |
+| **Recovery** | L'eleve confirme ou annule. Si ajoutee, Z3-AC11 (coherence intra-chapitre) detecte les doublons et archive automatiquement l'item de plus faible confidence. |
+| **AC** | Z5-AC11, Z3-AC11 |
+
+### EC-29 : LLM indisponible prolonge (> 5 min)
+
+| | |
+|---|---|
+| **Risque UX** | Aucune session possible. L'eleve ne peut pas reviser. |
+| **Traitement ideal** | Mode "Relecture active" avec flashcards statiques generees a partir des items existants (pas de LLM necessaire). |
+| **Copy** | "Les exercices ne sont pas disponibles pour le moment -- en attendant, revise ta lecon avec ces flashcards !" |
+| **Recovery** | Auto-check toutes les 30s. Retour au mode normal des que le LLM repond. |
+| **AC** | Z4-AC12 |
+
+### EC-30 : Session tardive (apres 21h)
+
+| | |
+|---|---|
+| **Risque UX** | L'eleve revise trop tard, mauvais sommeil, contre-productif. |
+| **Traitement ideal** | Nudge bienveillant + mode express pre-selectionne + reduction progressive. |
+| **Copy** | 21h : "Il est un peu tard -- une session express pour l'essentiel, et au dodo !" / 22h : "Il est tard ! Ton cerveau retient mieux quand tu dors bien. On reprend demain ?" |
+| **Recovery** | L'eleve peut forcer la session complete si il veut. Aucun blocage. |
+| **AC** | Z7-AC25 |

--- a/docs/ux/open-decisions.md
+++ b/docs/ux/open-decisions.md
@@ -1,0 +1,163 @@
+# Decisions produit ouvertes -- Revise Mieux
+
+> Decisions qui necessitent un arbitrage humain avant l'implementation. Classees par impact et urgence.
+
+---
+
+## Haute priorite (bloquant pour le Lot 0 P2)
+
+### OD-01 : App unique ou app parent separee ?
+
+**Question** : Le parent utilise-t-il la meme app que l'eleve (avec un switch de profil) ou une app/PWA distincte ?
+
+**Options** :
+- **(A) Meme app, profil parent** : un compte parent dans la meme app Expo. Toggle entre les vues. Moins de friction a l'installation (un seul store listing). Risque : l'eleve percoit l'app comme "celle de mes parents".
+- **(B) App parent separee** : PWA ou app legere. Separation nette des audiences. L'eleve ne voit jamais l'interface parent. Cout : deux codebases a maintenir.
+- **(C) Meme app, acces parent via web** : le parent accede a un dashboard web. Zero installation supplementaire. Le lien est dans le digest email. Cout : developper un dashboard web.
+
+**Recommandation** : Option (A) pour le Lot 0 avec un switch de profil clair. L'eleve ne doit jamais voir le dashboard parent par accident. Migrer vers (C) en post-MVP si le parent utilise principalement le digest.
+
+**Impact** : Architecture des routes Expo Router, strategie d'authentification, structure de navigation.
+
+---
+
+### OD-02 : Auto-evaluation vs scoring automatique en Lot 0
+
+**Question** : Le Lot 0 utilise l'auto-evaluation ("Je savais / Je ne savais pas") car le scoring LLM en temps reel n'est pas implemente. Quand basculer vers le scoring automatique ?
+
+**Options** :
+- **(A) Rester en auto-evaluation pour le Lot 0 entier** : simple, pas de dependance LLM en temps reel. Risque : l'eleve triche (surtout Lucas).
+- **(B) Scoring automatique MCQ des le Lot 0** : les MCQ ont une reponse deterministe, pas besoin de LLM. L'auto-evaluation reste pour les SHORT/KEYWORDS/RUBRIC.
+- **(C) Scoring LLM pour tout des le Lot 0** : experience complete mais dependance forte au LLM pendant les sessions.
+
+**Recommandation** : Option (B). Les MCQ representent ~40% des questions en difficulte 1. Le scoring automatique des MCQ est trivial (comparaison de choix). L'auto-evaluation reste pour les questions ouvertes jusqu'au scoring LLM.
+
+**Impact** : Composant de session (affichage feedback), API submit answer, logique de scoring.
+
+---
+
+### OD-03 : Position du bouton "Ajouter des pages" dans la navigation
+
+**Question** : Le bouton "Ajouter des pages" (Z5-AC11) est-il sur la carte du chapitre, dans le tab capture, ou les deux ?
+
+**Options** :
+- **(A) Sur la carte du chapitre uniquement** : l'eleve qui veut ajouter va naturellement sur le chapitre. Coherent avec le contexte.
+- **(B) Dans le tab capture avec selection du chapitre** : l'eleve qui ouvre l'app pour capturer commence par le tab capture. Il choisit ensuite "Nouveau chapitre" ou "Ajouter a [chapitre existant]".
+- **(C) Les deux** : duplication de l'entree mais couverture maximale des comportements.
+
+**Recommandation** : Option (C). Le bouton sur la carte du chapitre couvre le cas "je revise et je vois qu'il manque des pages". Le tab capture couvre le cas "j'ai pris des notes aujourd'hui, je veux les ajouter". Les deux sont des scenarios reels.
+
+**Impact** : Navigation capture, flow de selection de chapitre dans le tab capture.
+
+---
+
+## Priorite moyenne (impacte l'experience mais pas bloquant)
+
+### OD-04 : Moment d'affichage de la saisie d'emploi du temps
+
+**Question** : Z6-AC01 specifie que la saisie d'emploi du temps apparait au premier upload d'une matiere. Est-ce le bon moment, ou est-ce trop tot (friction dans le flow de capture) ?
+
+**Options** :
+- **(A) Au premier upload (spec actuelle)** : contextuel, l'eleve sait quand il a cette matiere. Friction : interrompt le flow capture -> pipeline.
+- **(B) Apres la premiere session completee** : l'eleve a deja vecu la valeur. Moins de friction initiale.
+- **(C) Dans les parametres uniquement** : aucune interruption. Risque : personne ne le remplit jamais.
+
+**Recommandation** : Option (A) avec un bouton "Plus tard" tres visible. Le moment est naturel ("tu viens de capturer ton cours de physique, quand as-tu physique ?"). Le mode degrade (Z6-AC11) protege contre le skip.
+
+**Impact** : Flow de creation de chapitre, timing des ecrans intermediaires.
+
+---
+
+### OD-05 : Presentation des regressions dans le debrief
+
+**Question** : Quand un item regresse (SOLID -> OK, OK -> FRAGILE), faut-il le montrer dans le debrief ou le masquer ?
+
+**Options** :
+- **(A) Montrer avec framing positif** : "Ce point a besoin d'un refresh -- on le revoit bientot." Transparent mais potentiellement anxiogene (Ines).
+- **(B) Masquer les regressions** : le debrief ne montre que les progressions positives. L'eleve decouvre la regression dans le dashboard. Risque : sentiment de tromperie.
+- **(C) Montrer uniquement si l'eleve est en mode "detail"** : debrief minimal (score + progressions), bouton "Voir le detail" pour les regressions.
+
+**Recommandation** : Option (C). Le debrief reste positif par defaut (progressions uniquement). L'eleve curieux peut voir le detail. Le framing growth mindset s'applique dans le detail.
+
+**Impact** : Composant debrief, structure de la reponse API debrief.
+
+---
+
+### OD-06 : Nombre de notifications parent par defaut
+
+**Question** : Quelles notifications parent sont activees par defaut a la liaison ?
+
+**Options** :
+- **(A) Tout active** : routine terminee, session manquee, inactivite, changement EDT. Risque : trop de bruit, le parent desactive tout.
+- **(B) Minimal** : uniquement routine terminee + digest hebdo. Le parent active le reste si il veut.
+- **(C) Progressive** : semaine 1 = routine terminee uniquement. Semaine 2 = ajout digest. Semaine 3 = ajout alertes inactivite.
+
+**Recommandation** : Option (B). Le signal positif (routine terminee) et le digest hebdo couvrent 80% du besoin. Les alertes negatives (session manquee, inactivite) sont opt-in pour eviter l'alert fatigue.
+
+**Impact** : ParentNotificationPref defaults, ecran de preferences parent.
+
+---
+
+### OD-07 : Traitement du chapitre demo apres le premier upload
+
+**Question** : Z8-AC01 specifie que le chapitre demo est archive automatiquement quand le premier vrai chapitre produit >= 1 item. Faut-il le supprimer ou l'archiver ?
+
+**Options** :
+- **(A) Archiver (masquer du dashboard)** : le chapitre demo reste en base, les masteries demo sont conservees. L'eleve peut le retrouver dans les parametres.
+- **(B) Supprimer** : nettoyage complet. Pas de pollution en base.
+
+**Recommandation** : Option (A). L'archivage est non-destructif. Si l'eleve veut revenir au chapitre demo (rare mais possible), il peut.
+
+**Impact** : Logique d'archivage, filtre dashboard.
+
+---
+
+## Priorite basse (post-MVP mais a documenter)
+
+### OD-08 : Gestion multi-enfants pour le parent
+
+**Question** : Un parent avec 2 enfants dans l'app (ex: Theo en 4e et sa soeur en 6e) voit-il un dashboard unifie ou deux dashboards separes ?
+
+**Recommandation** : Dashboard avec un selecteur d'enfant en haut. Notifications distinctes par enfant (Z6-AC39). A specifier en detail post-MVP.
+
+---
+
+### OD-09 : Partage de contenu entre eleves
+
+**Question** : Deux eleves de la meme classe peuvent-ils partager un chapitre (eviter le double OCR) ?
+
+**Recommandation** : Hors scope Lot 0. Le partage introduit des problemes de propriete des masteries, de RGPD, et d'integrite pedagogique. A evaluer en phase 2.
+
+---
+
+### OD-10 : Localisation (langues autres que le francais)
+
+**Question** : L'app est entierement en francais. Faut-il prevoir l'internationalisation des le depart ?
+
+**Recommandation** : Non pour le Lot 0. Les messages de feedback (growth mindset, debrief) sont trop culturellement specifiques pour etre traduits mecaniquement. Structurer le code pour i18n (fichiers de strings, pas de texte en dur dans les composants) mais ne pas investir dans les traductions.
+
+---
+
+### OD-11 : Monetisation et impact sur l'UX
+
+**Question** : Le modele freemium (prevu en phase 3 du PRD) impactera l'experience. Quelles fonctionnalites sont candidates au paywall ?
+
+**Recommandation** : A definir post-MVP. Ne pas designer de fonctionnalites avec un paywall en tete pour le Lot 0. Le risque est de degrader l'experience gratuite au point de perdre l'adoption.
+
+---
+
+## Resume par priorite
+
+| ID | Decision | Priorite | Bloquant pour |
+|----|----------|----------|---------------|
+| OD-01 | App unique vs separee (parent) | Haute | Architecture routes |
+| OD-02 | Auto-eval vs scoring auto MCQ | Haute | Composant session |
+| OD-03 | Position bouton "Ajouter des pages" | Haute | Navigation capture |
+| OD-04 | Moment saisie emploi du temps | Moyenne | Flow creation chapitre |
+| OD-05 | Regressions dans le debrief | Moyenne | Composant debrief |
+| OD-06 | Notifications parent par defaut | Moyenne | Preferences parent |
+| OD-07 | Demo archive vs supprime | Moyenne | Logique archivage |
+| OD-08 | Multi-enfants parent | Basse | Post-MVP |
+| OD-09 | Partage entre eleves | Basse | Post-MVP |
+| OD-10 | Internationalisation | Basse | Post-MVP |
+| OD-11 | Monetisation et paywall | Basse | Phase 3 |

--- a/docs/ux/personas.md
+++ b/docs/ux/personas.md
@@ -1,0 +1,198 @@
+# Personas -- Revise Mieux
+
+> 4 personas couvrant les deux audiences (eleve + parent) avec etats emotionnels, declencheurs de confiance et risques de decrochage.
+
+---
+
+## 1. Theo -- 13 ans, 4e -- eleve motive mais irregulier
+
+### Profil
+
+Theo aime comprendre mais n'aime pas reviser. Il prefere passer 10 minutes efficaces que 45 minutes a relire ses cours. Il utilise YouTube, Discord et joue a des jeux en ligne. Il est habitue aux interfaces rapides et n'a aucune tolerance pour les ecrans lents ou les formulaires.
+
+### Objectifs
+
+- Savoir quoi reviser ce soir en < 5 secondes
+- Terminer sa revision en 10-15 minutes max
+- Voir sa progression concretement (pas juste un message "bravo")
+- Ne pas avoir l'impression de faire "un devoir de plus"
+
+### Frustrations
+
+- "Je ne sais pas par ou commencer" -- le cours est un bloc de texte, pas un plan d'action
+- "J'ai revise mais je ne sais pas si ca a servi" -- pas de feedback sur ce qu'il maitrise
+- "C'est trop long" -- les sessions de revision classiques durent 30+ min sans fin claire
+- Les apps educatives qui "font bebe" avec des mascottes et des etoiles
+
+### Declencheurs de confiance
+
+- Premier quiz reussi en < 3 minutes apres l'install (chapitre demo)
+- Voir des items passer de UNKNOWN a FRAGILE apres une seule session
+- L'estimation de duree avant de commencer ("Ce soir : ~12 min")
+- L'ecran de cloture "Fini pour ce soir" -- permission explicite de fermer
+
+### Risques de decrochage
+
+- Pipeline OCR qui echoue au premier upload -- "ca marche pas"
+- Session trop longue un soir charge -- ferme l'app, culpabilise, ne revient pas
+- Monotonie des questions -- 5 QCM identiques d'affilee
+- Sentiment de regression visible -- "j'etais a OK et maintenant FRAGILE, c'est nul"
+
+### Etat emotionnel en ouvrant l'app
+
+**En semaine (soir)** : lassitude melee d'obligation. Il ouvre parce qu'il sait que c'est utile, pas parce qu'il en a envie. La friction doit etre nulle.
+
+**Avant un controle** : stress modere, motivation elevee. C'est le moment ou l'app a le plus de valeur si elle est directe ("Controle dans 2 jours -- voici tes points faibles").
+
+**Apres une absence de 3+ jours** : culpabilite legere. Si l'app affiche "tu as rate 3 sessions", il desinstalle. Si elle dit "Content de te revoir, on reprend doucement", il continue.
+
+---
+
+## 2. Ines -- 11 ans, 6e -- eleve appliquee mais anxieuse
+
+### Profil
+
+Ines est en 6e, premiere annee de college. Elle a toujours ete bonne eleve en primaire mais le rythme du college l'inquiete. Elle fait ses devoirs consciencieusement, relit ses cours plusieurs fois, mais doute toujours de sa preparation. Elle a un telephone depuis la rentree et utilise peu d'apps au-dela de WhatsApp et TikTok.
+
+### Objectifs
+
+- Etre sure d'avoir "tout revu" avant un controle
+- Comprendre ce qu'elle ne maitrise pas (identification precise des lacunes)
+- Etre rassuree que sa methode de revision est efficace
+- Ne pas etre jugee par un score brutal
+
+### Frustrations
+
+- L'incertitude : "est-ce que j'ai assez revise ?" -- pas de signal clair de completion
+- Les notes brutes sans explication : un "6/10" sans contexte est anxiogene
+- La sensation de ne pas progresser malgre l'effort
+- Les erreurs qui semblent definitives ("j'ai rate, c'est foutu")
+
+### Declencheurs de confiance
+
+- Le framing growth mindset : "Ce point a besoin d'un petit refresh" au lieu de "Tu as echoue"
+- L'ecran "Fini pour ce soir" -- validation explicite que son effort est suffisant
+- La barre de maitrise qui monte progressivement, meme apres une mauvaise session
+- Les micro-celebrations sur les transitions positives (FRAGILE -> OK)
+
+### Risques de decrochage
+
+- Un premier quiz trop difficile (questions NUMERIC ou RUBRIC en premier) -- "c'est trop dur pour moi"
+- Un score de session < 50% sans feedback encourageant -- confirme son anxiete
+- Trop de ValidationTasks qu'elle ne comprend pas -- "l'app me dit que c'est faux, c'est ma faute ?"
+- Regression visible sans explication pedagogique -- "j'avais OK et maintenant FRAGILE, j'ai tout perdu"
+
+### Etat emotionnel en ouvrant l'app
+
+**Quotidien** : application et legerete anxieuse. Elle veut bien faire. L'app doit lui donner un cadre clair ("fais ca, c'est suffisant") sans la surcharger.
+
+**Avant un controle** : anxiete elevee. L'app doit rassurer ("Tu es bien preparee pour demain") pas alarmer ("3 items encore FRAGILE").
+
+**Apres un echec** : decouragement. Le feedback doit transformer l'echec en action ("On revoit ca demain, c'est normal").
+
+---
+
+## 3. Lucas -- 15 ans, 3e -- eleve desengage
+
+### Profil
+
+Lucas est en 3e. Il ne voit pas l'interet de reviser : "ca sert a rien, le controle c'est du par-coeur de toute facon". Ses parents ont installe l'app sur son telephone et lui ont demande de l'utiliser. Il la considere comme une corvee supplementaire. Il utilise Instagram, Snapchat, joue a FIFA et regarde des streamers. Son seuil de friction est proche de zero.
+
+### Objectifs (declares)
+
+- Faire le minimum pour que ses parents le laissent tranquille
+- Que ca prenne le moins de temps possible
+- Ne pas se sentir infantilise
+
+### Objectifs (reels, non declares)
+
+- Eviter les mauvaises surprises en controle (ne pas avoir 4/20)
+- Comprendre les sujets qui l'interessent (certains chapitres le captent malgre tout)
+- Se sentir competent sans l'admettre
+
+### Frustrations
+
+- "Encore une app de devoirs" -- tout ce qui ressemble a du scolaire pur
+- Les longs onboardings avec des explications inutiles
+- Le sentiment d'etre surveille par ses parents via l'app
+- Les questions qu'il trouve betes ou evidentes (trop facile = insultant pour un 3e)
+
+### Declencheurs de confiance
+
+- La session demo de 3 min qui montre un resultat concret sans engagement
+- Le mode express : "Je n'ai pas beaucoup de temps ce soir" -- l'app respecte son temps
+- La montee en difficulte quand il reussit -- l'app le prend au serieux
+- L'absence de streak et de mecaniques culpabilisantes -- pas de "tu as perdu ta serie"
+
+### Risques de decrochage
+
+- Toute friction dans les 30 premieres secondes -- onboarding trop long, formulaire, permission camera
+- Questions trop faciles (QCM evidentes) -- "c'est pour les bebes"
+- Sentiment que le parent voit tout en temps reel -- "c'est un mouchard"
+- Absence totale de contenu apres un premier OCR echoue -- "ca marche pas" -> desinstalle
+
+### Etat emotionnel en ouvrant l'app
+
+**Habituel** : resistance passive. Il ouvre parce qu'on lui a demande, pas par choix. L'app a environ 30 secondes pour prouver sa valeur ou il ferme.
+
+**Moment de surprise** : un quiz ou il decouvre qu'il sait des choses le surprend agreablement. C'est le micro-moment d'accroche.
+
+**Apres un bon score** : fierte discrete. Il ne l'admettra jamais mais voir "SOLID" sur un item le satisfait.
+
+---
+
+## 4. Laurent -- 45 ans, pere de Theo -- parent cherchant de la reassurance
+
+### Profil
+
+Laurent est cadre, il travaille 50h/semaine. Il veut que Theo reussisse mais n'a ni le temps ni les competences pedagogiques pour l'aider chaque soir. Il a essaye plusieurs apps educatives : Duolingo (Theo a abandonne apres 2 semaines), une app de fiches (trop fastidieuse a configurer). Il cherche un outil qui "fonctionne tout seul" et lui donne un signal fiable sans qu'il ait a micro-manager.
+
+### Objectifs
+
+- Savoir si Theo revise regulierement (pas le detail, juste le signal)
+- Etre alerte uniquement en cas de risque reel (pas de spam)
+- Comprendre la proposition de valeur en < 60 secondes
+- Ne pas avoir a configurer ou maintenir quoi que ce soit apres le setup initial
+
+### Frustrations
+
+- Les apps qui noient dans les metriques sans actionabilite ("12 badges gagnes" -- et alors ?)
+- L'absence de signal : Theo dit "j'ai revise" mais Laurent n'a aucun moyen de verifier sans etre intrusif
+- Les faux signaux : un score de 80% sur des QCM faciles ne vaut rien
+- Le setup trop long : si ca prend plus de 5 minutes un mardi soir, il reporte indefiniment
+
+### Declencheurs de confiance
+
+- Le digest anticipé (J+2 apres liaison) : "Theo a revise 15 min en 2 sessions" -- preuve tangible
+- Le script 3 minutes : 2-3 questions orales a poser a Theo -- engagement parent minimal mais efficace
+- La transparence du score_confidence : "Score base sur 14 questions completes et 6 simplifiees" -- honnetete
+- La notification "routine terminee" le soir : un signal positif sans avoir a ouvrir l'app
+
+### Risques de decrochage
+
+- Aucun signal pendant les 6 premiers jours -- "ca sert a quoi cette app ?"
+- Trop de notifications (> 2/jour) -- desactive tout
+- Ne pas comprendre les labels (UNKNOWN, FRAGILE) -- jargon technique = perte de confiance
+- Ne pas percevoir d'amelioration apres 2 semaines -- "ca n'a rien change"
+
+### Etat emotionnel en ouvrant l'app
+
+**Premier acces** : scepticisme bienveillant. Il donne une chance a l'app mais s'attend a etre decu. L'onboarding parent (3 ecrans max) doit prouver la valeur rapidement.
+
+**Consultation ponctuelle** : verification rapide. Il ouvre le dashboard parent 1-2 fois par semaine, scanne les % de maitrise, et referme. L'information doit etre lisible en < 15 secondes.
+
+**Lors d'une alerte** : inquietude moderee. Il recoit "Theo n'a pas revise depuis 3 jours" et veut comprendre l'ampleur du probleme sans dramatiser. L'alerte doit etre factuelle et proposer une action concrete.
+
+---
+
+## Matrice d'interactions entre personas
+
+| Situation | Theo (motive) | Ines (anxieuse) | Lucas (desengage) | Laurent (parent) |
+|-----------|---------------|-----------------|-------------------|-----------------|
+| Premier quiz demo | Enthousiaste, enchaîne | Rassure, comprend le fonctionnement | Surpris positivement si < 3 min | Observe, valide la pertinence |
+| Premier OCR echoue | Frustre mais retente si guidance rapide | Inquiete, besoin de reassurance forte | Abandonne si pas de recovery immediat | Doute de l'outil technique |
+| Session quotidienne | Fait en 10 min, satisfait | Fait consciencieusement, besoin de "fini" | Fait en mode express ou skip | Recoit notification "routine terminee" |
+| Regression maitrise | Accepte si framing positif | Anxieuse, besoin de message growth mindset | Indifferent ou legerement agace | Veut comprendre la cause dans le digest |
+| Validation HITL | Fait rapidement les confirmations | Stresse sur "Je ne sais pas" | Ignore tout, clique partout | Confirme/corrige les 3 items proposes/semaine |
+| Controle dans 3 jours | Motivation maximale, controle blanc | Anxiete maximale, revise trop | Commence a reviser, tard | Verifie le digest pre-controle |
+| 5 jours sans ouvrir l'app | Revient naturellement | Culpabilise, besoin d'encouragement | Ne revient que si notification non-intrusif | Recoit alerte inactivite J+3 |

--- a/docs/ux/screen-inventory.md
+++ b/docs/ux/screen-inventory.md
@@ -1,0 +1,586 @@
+# Inventaire des ecrans -- Revise Mieux
+
+> Tous les ecrans de l'app eleve et parent, avec route Expo Router, intention UX, CTA principal, donnees necessaires et mapping ACs.
+>
+> **Legende** : (existant) = deja implemente dans mobile/ | (a creer) = manquant
+
+---
+
+## Tab Bar (eleve)
+
+3 onglets : Dashboard | Capture | Parametres
+
+---
+
+## 1. Dashboard eleve (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/(tabs)/index.tsx` |
+| **Intention** | Savoir quoi faire maintenant. En soiree : plan de soiree. Hors soiree : progression globale. |
+| **CTA principal** | "C'est parti !" sur la premiere etape non completee du plan de soiree |
+| **CTA secondaires** | "Capturer un cours", tap sur un chapitre, "Je n'ai pas beaucoup de temps" (mode express) |
+| **Comprehension < 3s** | "Ce soir : N activites, ~X min" (soiree) OU "X% maitrise globale" (hors soiree) |
+| **Ton emotionnel** | Encourageant, structure. "Bonsoir Hugo ! Ce soir : 3 activites, ~15 min." |
+| **Donnees** | `GET /api/v1/chapters`, calcul EveningPlan cote client ou serveur, masteries par chapitre |
+| **Mapping ACs** | Z6-AC30 (progression globale), Z7-AC01 (EveningPlan), Z7-AC02 (dashboard soiree), Z7-AC04 (estimation duree), Z7-AC05 (fini pour ce soir), Z7-AC08 (mode express), Z7-AC10 (rien a reviser), Z7-AC12 (arc emotionnel), Z8-AC01 (chapitre demo), Z8-AC02 (empty state) |
+
+### Wireframe textuel -- Etat soiree
+
+```
+┌─────────────────────────────────┐
+│ Bonsoir Hugo !                  │
+│ Ce soir : 3 activites, ~15 min  │
+│ [Je n'ai pas beaucoup de temps] │
+├─────────────────────────────────┤
+│ □ Saisis ton cours d'HG  ~2min  │
+│   [Capturer]                    │
+│                                 │
+│ □ Premiere revision HG   ~5min  │
+│   en attente de capture         │
+│                                 │
+│ □ Revision quotidienne  ~8min   │
+│   Physique + Maths              │
+│   [C'est parti !]               │
+├─────────────────────────────────┤
+│ PROGRESSION GLOBALE             │
+│ ████████░░░ 62% maitrise        │
+│ 5 SOLID  8 OK  4 FRAGILE       │
+├─────────────────────────────────┤
+│ MES CHAPITRES                   │
+│ ┌─ Physique-Chimie ───────────┐ │
+│ │ Densite et masse volumique  │ │
+│ │ ████████░░ 72%   8 items    │ │
+│ │ [Reviser]                   │ │
+│ └─────────────────────────────┘ │
+│ ┌─ Histoire-Geo ──────────────┐ │
+│ │ Les inegalites dans le monde│ │
+│ │ ████░░░░░░ 35%   12 items   │ │
+│ │ [Reviser]                   │ │
+│ └─────────────────────────────┘ │
+│                                 │
+│ [Capturer un cours]             │
+└─────────────────────────────────┘
+```
+
+### Wireframe textuel -- Empty state (premier usage)
+
+```
+┌─────────────────────────────────┐
+│ Bienvenue Hugo !                │
+│                                 │
+│      🧪                        │
+│  Aucun chapitre                 │
+│  Essaie le chapitre demo pour   │
+│  decouvrir l'app !              │
+│  [Charger le chapitre demo]     │
+│                                 │
+├─ OU ────────────────────────────┤
+│                                 │
+│  1. ✓ Compte cree               │
+│  2. → Photographie ton cours    │
+│     [Capturer]   30 secondes    │
+│  3.   Ta premiere revision      │
+│       ~5 min apres la capture   │
+│                                 │
+└─────────────────────────────────┘
+```
+
+---
+
+## 2. Capture photo (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/(tabs)/capture.tsx` |
+| **Intention** | Photographier les pages du cahier de l'eleve, rapidement et sans friction |
+| **CTA principal** | "Prendre une photo" / "Terminer" |
+| **CTA secondaires** | "Galerie" (importer depuis album), miniatures des pages prises, bouton "+" |
+| **Comprehension < 3s** | "Cadre ton cahier dans le rectangle" |
+| **Ton emotionnel** | Fonctionnel, rapide. Pas de decoration inutile. |
+| **Donnees** | Acces camera (expo-camera), stockage local temporaire des images, compteur pages X/30 |
+| **Mapping ACs** | Z2-AC03 (photo floue), Z5-AC11 (ajout incremental), Z8-AC03 (recovery premier OCR) |
+
+### Wireframe textuel
+
+```
+┌─────────────────────────────────┐
+│ Capturer un cours     3/30      │
+├─────────────────────────────────┤
+│ ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐│
+│                                 │
+│       📷                        │
+│   Cadre ton cahier              │
+│   dans le rectangle             │
+│                                 │
+│   [Prendre une photo]           │
+│                                 │
+│ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘│
+│                                 │
+│ Pages capturees                 │
+│ [1] [2] [3] [+]                │
+│                                 │
+│ [Galerie]      [Terminer ->]    │
+└─────────────────────────────────┘
+```
+
+---
+
+## 3. Parametres (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/(tabs)/settings.tsx` |
+| **Intention** | Configurer le profil, l'emploi du temps, inviter un parent, gerer les notifications |
+| **CTA principal** | Navigation vers les sous-ecrans de config |
+| **CTA secondaires** | Inviter un parent (badge si non lie), emploi du temps, notifications |
+| **Comprehension < 3s** | Liste de parametres organisee par categorie |
+| **Ton emotionnel** | Neutre, professionnel |
+| **Donnees** | Profil utilisateur, ScheduleSlots, ParentLink status, NotificationPrefs |
+| **Mapping ACs** | Z6-AC01 (emploi du temps), Z6-AC20 (opt-out parent), Z6-AC44 (liaison parent), Z8-AC07 (invitation parent) |
+
+---
+
+## 4. Onboarding (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/onboarding.tsx` |
+| **Intention** | Guider l'eleve vers sa premiere action (demo ou capture) en < 60 secondes |
+| **CTA principal** | "Capturer" (premier cours) OU "Charger le chapitre demo" |
+| **CTA secondaires** | Aucun -- parcours lineaire |
+| **Comprehension < 3s** | "Pret en 3 etapes" avec checklist visuelle |
+| **Ton emotionnel** | Accueillant, simple. Aucun formulaire. |
+| **Donnees** | Statut onboarding (etapes completees), user profile minimal |
+| **Mapping ACs** | Z8-AC01 (demo), Z8-AC02 (empty state), Z8-AC08 (sequence deterministe) |
+
+---
+
+## 5. Processing / Pipeline OCR (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/processing.tsx` |
+| **Intention** | Informer l'eleve que le traitement est en cours, reduire l'anxiete d'attente |
+| **CTA principal** | Aucun pendant le traitement. "Tu peux fermer l'app" apres 30s. |
+| **CTA secondaires** | Bouton retour, notification push a la fin |
+| **Comprehension < 3s** | Animation + message contextuel ("Lecture de tes pages...", "Creation des questions...", "Presque fini...") |
+| **Ton emotionnel** | Rassurant, progressif. 3 phases visuelles distinctes. |
+| **Donnees** | Pipeline status (polling ou SSE), progression par page |
+| **Mapping ACs** | Z8-AC04 (ecran progression), Z2-AC01 (carte partielle), Z2-AC10 (streaming premiere page) |
+
+---
+
+## 6. Detail chapitre / Carte de lecon (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/chapter/[id].tsx` |
+| **Intention** | Voir le contenu d'un chapitre, comprendre ou on en est par notion, lancer une session |
+| **CTA principal** | "Lancer une session" |
+| **CTA secondaires** | "Ajouter des pages", "Voir les items ignores", deployer/replier les notions, creer un exam |
+| **Comprehension < 3s** | Barre de maitrise globale + notions en accordeon avec leur propre barre |
+| **Ton emotionnel** | Informatif, organise. L'eleve identifie visuellement ses points faibles. |
+| **Donnees** | `GET /api/v1/chapters/{id}/lesson-card`, `GET /api/v1/masteries`, notions avec items |
+| **Mapping ACs** | Z7-AC15 (notions par concept_tag), Z7-AC16 (accordeon + maitrise par notion), Z5-AC04 (revision courante unique), Z5-AC11 (bouton ajouter des pages), Z2-AC01 (carte partielle), Z3-AC06 (utilisable avec 0 validations), Z3-AC16 (items ignores recuperables) |
+
+### Wireframe textuel
+
+```
+┌─────────────────────────────────┐
+│ <- Physique-Chimie              │
+│ Densite et masse volumique      │
+│ ████████░░ 72% maitrise         │
+│ 8 items · revise il y a 1 jour  │
+├─────────────────────────────────┤
+│ [Lancer une session]            │
+│ [Ajouter des pages]             │
+├─────────────────────────────────┤
+│ NOTIONS                         │
+│                                 │
+│ ▼ Masse volumique (rho)   44%  │
+│   ███░░░░░                      │
+│   · rho = m/V          FRAGILE  │
+│   · unite SI            OK      │
+│   · definition          SOLID   │
+│                                 │
+│ ▶ Deplacement d'eau     100%   │
+│   ████████ (3 items SOLID)      │
+│                                 │
+│ ▶ Materiaux et densite   0%    │
+│   ░░░░░░░░ (2 items UNKNOWN)   │
+├─────────────────────────────────┤
+│ ⚠ 2 zones a verifier           │
+│ [Voir les validations]          │
+├─────────────────────────────────┤
+│ Points non verifies (1)         │
+│ · [Reactiver]                   │
+└─────────────────────────────────┘
+```
+
+---
+
+## 7. Session de revision (existant)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/session/[id].tsx` |
+| **Intention** | Repondre a des questions adaptees, recevoir du feedback immediat, progresser |
+| **CTA principal** | "Valider" (soumettre la reponse) |
+| **CTA secondaires** | "Passer", "Voir ma lecon", "Je ne comprends pas", "Signaler une erreur", choices MCQ |
+| **Comprehension < 3s** | Question en cours + progression (X/Y) + barre de progression visuelle |
+| **Ton emotionnel** | Focus, encourageant. Le feedback est toujours factuel et positif. |
+| **Donnees** | Session ID, questions[], current_question_index, attempt responses |
+| **Mapping ACs** | Z1-AC01 a AC12 (transitions maitrise), Z1-AC14 (micro-celebrations), Z4-AC04 (reprise session), Z4-AC09 (feedback enrichi), Z4-AC10 (bouton passer), Z6-AC05 (evening_first 100% UNKNOWN), Z1-AC21 (voir lecon), Z1-AC22 (reformulation), Z1-AC23 (scoring graduel), Z3-AC12 (signalement erreur), Z3-AC15 (anti-clicking rapide) |
+
+### Wireframe textuel -- Question MCQ
+
+```
+┌─────────────────────────────────┐
+│ Question 3/8        ████░░░░    │
+├─────────────────────────────────┤
+│                                 │
+│ Vrai ou faux :                  │
+│ La masse volumique est le       │
+│ rapport de la masse d'un corps  │
+│ sur son volume.                 │
+│                                 │
+│ ┌───────────────────────────┐   │
+│ │ [A] Vrai                  │   │
+│ └───────────────────────────┘   │
+│ ┌───────────────────────────┐   │
+│ │ [B] Faux                  │   │
+│ └───────────────────────────┘   │
+│                                 │
+│ [Passer]  [Voir ma lecon]       │
+│                                 │
+│        [Valider]                │
+└─────────────────────────────────┘
+```
+
+### Wireframe textuel -- Feedback (reponse incorrecte)
+
+```
+┌─────────────────────────────────┐
+│ Question 3/8        ████░░░░    │
+├─────────────────────────────────┤
+│                                 │
+│ ❌ Pas tout a fait...           │
+│                                 │
+│ Reponse attendue :              │
+│ "Vrai -- rho = m / V"          │
+│                                 │
+│ Ce qui manquait :               │
+│ La formule associee             │
+│                                 │
+│ 💡 Retiens que la masse         │
+│ volumique est toujours le       │
+│ rapport masse / volume.         │
+│                                 │
+│ [Signaler une erreur]           │
+│                                 │
+│        [Suivant ->]             │
+└─────────────────────────────────┘
+```
+
+---
+
+## 8. Debrief session (sous-ecran de session)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | Composant `DebriefView` dans `app/session/[id].tsx` |
+| **Intention** | Valoriser l'effort, montrer les progressions, donner le prochain objectif |
+| **CTA principal** | "Terminer" |
+| **CTA secondaires** | "Encore une session" (si items non couverts), "Retour au chapitre" |
+| **Comprehension < 3s** | Score X/Y + liste des progressions positives |
+| **Ton emotionnel** | Celebratoire et positif. Mettre en avant les progres, pas les echecs. |
+| **Donnees** | `GET /api/v1/sessions/{id}/debrief` |
+| **Mapping ACs** | Z1-AC15 (debrief fin session), Z1-AC14 (micro-celebrations), Z7-AC05 (ecran cloture soiree) |
+
+---
+
+## 9. Validation HITL (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/validation/[id].tsx` |
+| **Intention** | Permettre a l'eleve ou au parent de confirmer, corriger ou deleguer un item incertain |
+| **CTA principal** | "Confirmer" / "Corriger" / "Je ne sais pas" |
+| **CTA secondaires** | "Ignorer", navigation entre les validations |
+| **Comprehension < 3s** | "L'IA a detecte : [suggestion]. C'est correct ?" |
+| **Ton emotionnel** | Neutre, collaboratif. L'eleve aide l'app, pas l'inverse. |
+| **Donnees** | `GET /api/v1/validations`, `POST /api/v1/validations/{id}/resolve` |
+| **Mapping ACs** | Z3-AC01 (gabarits bloques), Z3-AC02 (confirmer), Z3-AC03 (corriger), Z3-AC04 (je ne sais pas), Z3-AC05 (ignorer), Z3-AC06 (chapitre utilisable avec 0 validations), Z3-AC09 (pas de validation si confidence haute) |
+
+### Wireframe textuel
+
+```
+┌─────────────────────────────────┐
+│ Verification 1/3                │
+├─────────────────────────────────┤
+│ L'IA a detecte :                │
+│                                 │
+│ ┌───────────────────────────┐   │
+│ │ "rho = m / V"             │   │
+│ │ (formule de la masse      │   │
+│ │  volumique)               │   │
+│ └───────────────────────────┘   │
+│                                 │
+│ C'est correct ?                 │
+│                                 │
+│ [✓ Confirmer]                   │
+│ [✏ Corriger]                    │
+│ [? Je ne sais pas]              │
+│ [Ignorer]                       │
+│                                 │
+│ 6 zones a verifier              │
+│ Tes exercices seront plus       │
+│ precis apres verification.      │
+└─────────────────────────────────┘
+```
+
+---
+
+## 10. Ecran de recovery OCR (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/recovery.tsx` (ou composant dans `processing.tsx`) |
+| **Intention** | Guider l'eleve apres un echec OCR sans le bloquer |
+| **CTA principal** | "Reprendre les photos" |
+| **CTA secondaires** | "Essayer quand meme" (si items partiels), "Chapitre demo" (si premier upload) |
+| **Comprehension < 3s** | "Les photos sont un peu difficiles a lire. Pas de panique !" |
+| **Ton emotionnel** | Empathique, deculpabilisant. Conseils visuels concrets. |
+| **Donnees** | Pipeline status, nombre de pages echouees, items partiels generes |
+| **Mapping ACs** | Z8-AC03 (UX recovery premier OCR), Z2-AC03 (photo floue), Z2-AC07 (diagnostic impossible si 0 items) |
+
+### Wireframe textuel
+
+```
+┌─────────────────────────────────┐
+│ Les photos sont un peu          │
+│ difficiles a lire.              │
+│ Pas de panique !                │
+│                                 │
+│ ┌────┐ ┌────┐ ┌────┐           │
+│ │ ☀️ │ │ 📐 │ │ ✍️ │           │
+│ │Bon │ │Bien│ │Lis-│           │
+│ │ecl.│ │cad.│ │ible│           │
+│ └────┘ └────┘ └────┘           │
+│                                 │
+│ [Reprendre les photos]          │
+│                                 │
+│ [Essayer quand meme]            │
+│ 2 items quand meme detectes     │
+│                                 │
+│ [S'entrainer sur le chapitre    │
+│  demo en attendant]             │
+└─────────────────────────────────┘
+```
+
+---
+
+## 11. Creation d'exam (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/exam/create.tsx` |
+| **Intention** | Enregistrer un controle a venir pour activer le resserrement des intervalles |
+| **CTA principal** | "Creer le controle" |
+| **CTA secondaires** | Selection matiere, date, chapitres (pre-coches heuristique 6 semaines), notions (toggles) |
+| **Comprehension < 3s** | "Quand est ton prochain controle ?" |
+| **Ton emotionnel** | Rapide, structure. Parcours complet < 90 secondes. |
+| **Donnees** | Chapitres par matiere, notions par chapitre, exams existants |
+| **Mapping ACs** | Z6-AC10 (creation exam), Z7-AC17 (selection par notion), Z7-AC18 (auto-suggestion chapitres), Z1-AC08 (resserrement) |
+
+---
+
+## 12. Controle blanc (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/session/[id].tsx` (meme composant, type `mock_exam`) |
+| **Intention** | Simuler un controle dans les conditions reelles, evaluer la preparation |
+| **CTA principal** | "Lancer le controle blanc" |
+| **Comprehension < 3s** | "Controle blanc [matiere] -- X questions, ~Y min" |
+| **Ton emotionnel** | Serieux mais pas stressant. "Simuler pour se preparer, pas pour se juger." |
+| **Donnees** | Exam ID, questions multi-chapitres, score_confidence |
+| **Mapping ACs** | Z6-AC09 (mock exam multi-chapitres), Z4-AC07 (non bloque par session daily), Z1-AC16 (caveat score si items non valides) |
+
+---
+
+## 13. Emploi du temps (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/schedule.tsx` ou sous-ecran de `settings.tsx` |
+| **Intention** | Renseigner/modifier les creneaux de cours pour activer les notifications et pre_class |
+| **CTA principal** | Cocher les creneaux dans la grille Lu-Ve x Matin/AM |
+| **CTA secondaires** | "Plus tard" (mode degrade accepte) |
+| **Comprehension < 3s** | "Quand as-tu [Matiere] dans la semaine ?" |
+| **Ton emotionnel** | Rapide, low-friction. Grille visuelle, pas de formulaire. |
+| **Donnees** | ScheduleSlots par matiere, ScheduleExceptions |
+| **Mapping ACs** | Z6-AC01 (saisie contextuelle), Z6-AC11 (mode degrade), Z6-AC16 (exceptions) |
+
+---
+
+## 14. Invitation parent (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/invite-parent.tsx` (ou modal depuis settings) |
+| **Intention** | Generer un code de liaison et le partager au parent |
+| **CTA principal** | "Partager le code" (share sheet OS) |
+| **CTA secondaires** | "Copier le code", "Plus tard" |
+| **Comprehension < 3s** | Code 6 caracteres visible en grand + instruction "Envoie ce code a ton parent" |
+| **Ton emotionnel** | Simple, rapide. Pas de friction. |
+| **Donnees** | Code genere via `POST /api/v1/parent/link-code` |
+| **Mapping ACs** | Z6-AC44 (liaison parent-eleve), Z8-AC07 (timing optimal apres 1ere session) |
+
+---
+
+## 15. Dashboard parent (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/parent/dashboard.tsx` (ou app parent separee) |
+| **Intention** | Vue d'ensemble rapide de la progression de l'enfant, sans micro-management |
+| **CTA principal** | "Script 3 min" (questions orales a poser) |
+| **CTA secondaires** | Voir le detail par chapitre, gerer notifications, ValidationTasks |
+| **Comprehension < 3s** | "[Prenom] : X% maitrise globale, Y sessions cette semaine" |
+| **Ton emotionnel** | Rassurant, factuel. Labels traduits (pas UNKNOWN mais "Pas encore vu"). |
+| **Donnees** | Mastery breakdown par chapitre, sessions completees, digest data |
+| **Mapping ACs** | Z6-AC27 (digest hebdo), Z6-AC29 (labels traduits), Z6-AC30 (progression globale), Z1-AC17 (script 3 min), Z8-AC05 (onboarding parent) |
+
+### Wireframe textuel
+
+```
+┌─────────────────────────────────┐
+│ Theo · 4e                       │
+│ 68% maitrise globale            │
+│ 4 sessions cette semaine, 42min │
+├─────────────────────────────────┤
+│ CHAPITRES                       │
+│                                 │
+│ Physique · Densite         72%  │
+│ ████████░░  Bien acquis         │
+│                                 │
+│ Histoire · Inegalites      35%  │
+│ ████░░░░░░  En cours            │
+│ ⚠ 2 points en verification     │
+│                                 │
+│ [Script 3 min]                  │
+├─────────────────────────────────┤
+│ CETTE SEMAINE                   │
+│ · 4 routines completees / 5     │
+│ · 1 session manquee (mercredi)  │
+│                                 │
+│ PROCHAINS CONTROLES             │
+│ · Physique : dans 5 jours       │
+│   [Voir le detail]              │
+├─────────────────────────────────┤
+│ Validations en attente (2)      │
+│ [Voir]                          │
+└─────────────────────────────────┘
+```
+
+---
+
+## 16. Onboarding parent (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/parent/onboarding.tsx` (3 ecrans swipeable) |
+| **Intention** | Expliquer la proposition de valeur en 30 secondes |
+| **CTA principal** | Swipe ou "Suivant" pour progresser, "Passer" |
+| **Comprehension < 3s** | Ecran 1 : "Voici ce que fait [Prenom]" avec schema photo->quiz->maitrise |
+| **Ton emotionnel** | Professionnel, rassurant. Pas enfantin. |
+| **Donnees** | Prenom enfant, statut sessions (si deja faites) |
+| **Mapping ACs** | Z8-AC05 (onboarding parent 3 ecrans), Z8-AC06 (digest anticipe) |
+
+---
+
+## 17. Angles morts (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/blind-spots.tsx` (ou onglet dans dashboard) |
+| **Intention** | Identifier les chapitres sans controle a venir -- zones de risque |
+| **CTA principal** | "Creer un controle" (pre-rempli avec le chapitre) |
+| **Comprehension < 3s** | "N chapitres sans controle prevu. Verifie avec ton prof !" |
+| **Ton emotionnel** | Proactif, non anxiogene. Information actionnable. |
+| **Donnees** | Chapitres sans exam actif, historique controles par matiere |
+| **Mapping ACs** | Z7-AC19 (angles morts), Z7-AC20 (prediction interro surprise), Z7-AC21 (alerte notion fragile) |
+
+---
+
+## 18. Fiche PDF (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/chapter/[id]/pdf.tsx` (ou modal) |
+| **Intention** | Generer une fiche de revision papier pour l'etude sans telephone |
+| **CTA principal** | "Telecharger la fiche" |
+| **CTA secondaires** | Choix du nombre de questions, selection par chapitre ou matiere |
+| **Comprehension < 3s** | "Fiche revision -- 15 questions, Physique-Chimie" |
+| **Ton emotionnel** | Utilitaire, efficace |
+| **Donnees** | Items urgents, questions en cache, generation PDF serveur |
+| **Mapping ACs** | Z7-AC23 (fiche PDF), Z7-AC24 (report resultats papier) |
+
+---
+
+## 19. Report papier (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | `app/paper-report/[id].tsx` (ou via QR code) |
+| **Intention** | Reporter rapidement les resultats d'une fiche papier |
+| **CTA principal** | "Valider" le report |
+| **Comprehension < 3s** | Checklist rapide : ✓/✗ pour chaque question |
+| **Ton emotionnel** | Rapide, valorisant. "Tu as revise 12 points en etude !" |
+| **Donnees** | PDF log avec item_ids, resultats tap ✓/✗ |
+| **Mapping ACs** | Z7-AC24 (report resultats), Z7-AC26 (impact maitrise) |
+
+---
+
+## 20. Ecran de cloture soiree (a creer)
+
+| Champ | Valeur |
+|-------|--------|
+| **Route** | Composant modal apres la derniere session du plan |
+| **Intention** | Donner la permission explicite de fermer l'app |
+| **CTA principal** | "Fermer" |
+| **Comprehension < 3s** | "Bravo ! Soiree terminee en X min." |
+| **Ton emotionnel** | Celebratoire, conclusif. L'eleve peut aller faire autre chose. |
+| **Donnees** | EveningPlan.completed_at, resume matrieres, progressions |
+| **Mapping ACs** | Z7-AC05 (etat fini pour ce soir), Z7-AC13 (notification parent routine terminee) |
+
+---
+
+## Resume : ecrans existants vs manquants
+
+| # | Ecran | Route | Statut |
+|---|-------|-------|--------|
+| 1 | Dashboard eleve | `app/(tabs)/index.tsx` | Existant (a enrichir avec plan soiree) |
+| 2 | Capture photo | `app/(tabs)/capture.tsx` | Existant |
+| 3 | Parametres | `app/(tabs)/settings.tsx` | Existant (a enrichir) |
+| 4 | Onboarding | `app/onboarding.tsx` | Existant |
+| 5 | Processing OCR | `app/processing.tsx` | Existant |
+| 6 | Detail chapitre | `app/chapter/[id].tsx` | Existant |
+| 7 | Session revision | `app/session/[id].tsx` | Existant |
+| 8 | Debrief session | composant dans session | Existant |
+| 9 | Validation HITL | `app/validation/[id].tsx` | **A creer** |
+| 10 | Recovery OCR | `app/recovery.tsx` | **A creer** |
+| 11 | Creation exam | `app/exam/create.tsx` | **A creer** |
+| 12 | Controle blanc | reutilise session | Existant (a parametrer) |
+| 13 | Emploi du temps | `app/schedule.tsx` | **A creer** |
+| 14 | Invitation parent | `app/invite-parent.tsx` | **A creer** |
+| 15 | Dashboard parent | `app/parent/dashboard.tsx` | **A creer** |
+| 16 | Onboarding parent | `app/parent/onboarding.tsx` | **A creer** |
+| 17 | Angles morts | `app/blind-spots.tsx` | **A creer** |
+| 18 | Fiche PDF | `app/chapter/[id]/pdf.tsx` | **A creer** |
+| 19 | Report papier | `app/paper-report/[id].tsx` | **A creer** |
+| 20 | Cloture soiree | composant modal | **A creer** |
+
+**Bilan** : 8 ecrans existants, 12 ecrans a creer. Les ecrans existants couvrent le Lot 0 P1 (boucle minimale). Les ecrans manquants couvrent le Lot 0 P2 et le MVP complet.

--- a/docs/ux/state-model.md
+++ b/docs/ux/state-model.md
@@ -1,0 +1,164 @@
+# Modele d'etats par ecran -- Revise Mieux
+
+> Pour chaque ecran critique, les 11 etats d'affichage sont decrits explicitement.
+>
+> Les etats couverts : Default, Loading, Processing, Success, Empty, Partial, Stale, OCR Uncertainty, Error, Blocked, Retry.
+
+---
+
+## 1. Dashboard eleve
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default (soiree)** | Plan de soiree avec etapes, estimation duree, bouton "C'est parti" | EveningPlan calcule, sessions composees |
+| **Default (hors soiree)** | Progression globale, liste des chapitres avec barres de maitrise | `GET /chapters` + masteries |
+| **Loading** | Skeleton : rectangles animes pour header, plan, chapitres | `isLoading = true` sur le fetch initial |
+| **Processing** | Bandeau "Traitement de tes photos en cours..." avec lien vers processing.tsx | Pipeline J0 actif pour un chapitre |
+| **Success** | Plan de soiree avec coche verte sur une etape terminee, message de transition | Apres completion d'une session, refresh du plan |
+| **Empty** | Checklist 3 etapes + chapitre demo. "Aucun chapitre" avec CTA "Charger le chapitre demo" | 0 chapitres en base, Z8-AC01/AC02 |
+| **Partial** | Chapitres charges mais plan de soiree incomplet (schedule partiel) | Certaines matieres sans ScheduleSlots, bandeau "Ajoute ton emploi du temps" |
+| **Stale** | Donnees affichees normalement, indicateur discret de synchro | Pull-to-refresh disponible, background refresh en cours |
+| **OCR Uncertainty** | Badge sur le chapitre : "2 zones a verifier" | Items avec `validation_required = true` |
+| **Error** | Message "Impossible de charger tes chapitres" + bouton "Reessayer" | Erreur reseau sur `GET /chapters` |
+| **Blocked** | N/A -- le dashboard n'est jamais bloque | |
+| **Retry** | Bouton "Reessayer" apres un echec reseau | Relance le fetch |
+
+---
+
+## 2. Capture photo
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | Zone camera avec guidage "Cadre ton cahier", compteur pages, vignettes | Camera active, aucune photo prise |
+| **Loading** | Spinner bref pendant l'initialisation camera | Chargement expo-camera |
+| **Processing** | N/A -- le processing est sur un ecran dedie | |
+| **Success** | Flash visuel + vignette ajoutee a la bande de pages | Photo capturee, ajoutee a la liste locale |
+| **Empty** | Zone camera vide, bouton "Terminer" inactif (opacite reduite) | 0 pages capturees |
+| **Partial** | Vignettes des pages capturees + bouton "+" pour en ajouter | Entre 1 et 29 pages |
+| **Stale** | N/A -- tout est local | |
+| **OCR Uncertainty** | N/A -- pre-processing (l'analyse vient apres) | |
+| **Error** | "Camera indisponible" + option "Importer depuis la galerie" | Permission camera refusee ou hardware |
+| **Blocked** | "30 pages maximum atteintes" -- bouton capture desactive | pages.length >= 30 |
+| **Retry** | "Permission camera requise" + bouton vers les reglages | Apres refus de permission |
+
+---
+
+## 3. Processing (pipeline OCR)
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | N/A -- cet ecran n'a pas d'etat au repos | |
+| **Loading** | Phase 1 : "Lecture de tes pages..." avec animation de scan | Progression 0-30% |
+| **Processing** | Phase 2 : "Creation des questions..." puis Phase 3 : "Presque fini..." | Progression 30-70% puis 70-100% |
+| **Success** | Redirection automatique vers le chapitre cree | Pipeline termine avec >= 1 item valide |
+| **Empty** | N/A -- redirige vers Recovery si 0 items | |
+| **Partial** | "3/10 pages analysees" avec items deja disponibles | Traitement en cours, pages traitees progressivement (Z2-AC01) |
+| **Stale** | "Tu peux fermer l'app, on te previent quand c'est pret" (apres 30s) | Notification push programmee a la fin du pipeline |
+| **OCR Uncertainty** | N/A -- l'incertitude est geree apres, sur le chapitre | |
+| **Error** | Redirection vers l'ecran Recovery (Z8-AC03) | Pipeline echoue ou timeout > 60s |
+| **Blocked** | N/A | |
+| **Retry** | Bouton "Reessayer" sur l'ecran Recovery | Relance le pipeline J0 |
+
+---
+
+## 4. Detail chapitre / Carte de lecon
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | Barre maitrise globale + notions en accordeon + bouton "Lancer une session" | Lesson card + masteries charges |
+| **Loading** | Skeleton : barre de maitrise grise, accordeons placeholder | `GET /chapters/{id}/lesson-card` + `GET /masteries` |
+| **Processing** | Bandeau "Analyse des pages 4-6 en cours..." avec progression | Pipeline incremental actif (Z2-AC14) |
+| **Success** | Animation transition maitrise apres une session completee | Refresh des masteries apres session |
+| **Empty** | "Aucun contenu extrait. Verifie la qualite des photos et re-uploade." | 0 items valides (Z2-AC07) |
+| **Partial** | Items des pages traitees affiches + placeholders pages en cours | Pipeline partiel (Z2-AC01), indicateur "3/10 pages analysees" |
+| **Stale** | Donnees affichees, fond refresh en cours | Cache masteries potentiellement obsolete |
+| **OCR Uncertainty** | Badges "Zone illisible · page 4" + bandeau "N zones a verifier" | Pages en FAILED, items avec validation_required |
+| **Error** | "Impossible de charger le chapitre" + bouton "Reessayer" | Erreur reseau |
+| **Blocked** | Bouton diagnostic desactive + message "Aucun contenu n'a pu etre extrait" | 0 items valides (Z2-AC07) |
+| **Retry** | Badge "Exercices non generes · page X" avec bouton "Reessayer" | Z2-AC11, max 3 retries manuels |
+
+---
+
+## 5. Session de revision
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | Question affichee + barre progression X/Y + zone de reponse | Session IN_PROGRESS, question courante |
+| **Loading** | Skeleton question + spinner pendant la composition | `POST /sessions/daily` + `GET /sessions/{id}/questions` |
+| **Processing** | N/A -- le LLM a deja genere les questions (lazy cache) | |
+| **Success** | Feedback vert "Bonne reponse !" + micro-celebration si transition positive | Score >= 0.7, transition maitrise positive |
+| **Empty** | "Tous tes items sont a jour ! Prochaine revision : [date]" + option consolidation | Aucun item eligible (Z4-AC13) |
+| **Partial** | "Petite session rapide -- N questions sur ce chapitre" | < 5 items dans le chapitre (Z4-AC11) |
+| **Stale** | N/A -- les questions sont fraiches a la composition | |
+| **OCR Uncertainty** | Question avec badge "Contenu en cours de verification" | Item avec validation_required, gabarit simple uniquement |
+| **Error** | "Preparation de tes exercices en cours... reessaie dans quelques secondes" | LLM timeout (Z4-AC06) |
+| **Blocked** | N/A -- la session ne bloque jamais (gabarits simples si validation en cours) | |
+| **Retry** | Apres 10s LLM timeout : mode "Relecture active" avec flashcards statiques | Fallback Z4-AC12 |
+
+---
+
+## 6. Validation HITL
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | Item avec suggestion + 4 boutons d'action (Confirmer/Corriger/JNSP/Ignorer) | ValidationTask PENDING |
+| **Loading** | Spinner pendant le chargement des validations | `GET /validations` |
+| **Processing** | N/A | |
+| **Success** | Confirmation visuelle "Mis a jour !" + navigation vers la validation suivante | Task resolue (CONFIRMED/CORRECTED) |
+| **Empty** | "Aucune verification en attente. Tout est bon !" | 0 ValidationTasks PENDING (Z3-AC09) |
+| **Partial** | N/A | |
+| **Stale** | N/A | |
+| **OCR Uncertainty** | Crop de la page source affiche a cote de la suggestion pour comparaison | Item a faible confidence |
+| **Error** | "Impossible de sauvegarder ta reponse" + bouton "Reessayer" | Erreur reseau sur POST |
+| **Blocked** | N/A | |
+| **Retry** | Bouton "Reessayer" apres echec de sauvegarde | Relance le POST |
+
+---
+
+## 7. Dashboard parent
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | Maitrise globale de l'enfant + chapitres + activite semaine | Donnees fraiches |
+| **Loading** | Skeleton dashboard | Chargement initial |
+| **Processing** | N/A | |
+| **Success** | N/A (pas d'action mutative depuis le dashboard parent) | |
+| **Empty (enfant n'a pas commence)** | "[Prenom] n'a pas encore commence -- vous serez notifie des sa premiere session" | 0 sessions, 0 chapitres |
+| **Partial** | Chapitres avec items en verification mentionnes | Items validation_required |
+| **Stale** | Donnees du dernier digest, indicateur "Mis a jour il y a 2j" | Parent ne consulte pas frequemment |
+| **OCR Uncertainty** | "2 points en verification -- exercices simplifies en attendant" | Items validation_required dans le chapitre |
+| **Error** | "Connexion perdue -- donnees du dernier chargement affichees" | Erreur reseau |
+| **Blocked** | N/A | |
+| **Retry** | Pull-to-refresh | |
+
+---
+
+## 8. Onboarding eleve
+
+| Etat | Ce que l'utilisateur voit | Comportement technique |
+|------|--------------------------|----------------------|
+| **Default** | Checklist 3 etapes + CTAs | Premier acces |
+| **Loading** | Spinner sur le bouton "Charger le chapitre demo" | POST /onboarding/seed-demo |
+| **Processing** | N/A | |
+| **Success** | Redirection vers le dashboard avec le chapitre demo | Seed reussi |
+| **Empty** | N/A (c'est l'etat initial par definition) | |
+| **Partial** | N/A | |
+| **Stale** | N/A | |
+| **OCR Uncertainty** | N/A | |
+| **Error** | "Impossible de charger le chapitre demo" + fallback vers le dashboard vide | Erreur seed |
+| **Blocked** | N/A | |
+| **Retry** | Bouton "Reessayer" ou navigation directe vers capture | |
+
+---
+
+## Matrice recapitulative : etats critiques par ecran
+
+| Ecran | Etats les plus risques (UX) | AC de reference |
+|-------|---------------------------|----------------|
+| Dashboard | Empty (premier usage), Error (perte de confiance) | Z8-AC01, Z8-AC02 |
+| Capture | Error (permission camera), Blocked (30 pages) | Z2-AC03 |
+| Processing | Error (pipeline echoue, premier upload critique) | Z8-AC03, Z8-AC04 |
+| Detail chapitre | Partial (pages en cours), OCR Uncertainty (zones illisibles) | Z2-AC01, Z2-AC07 |
+| Session | Empty (rien a reviser), Error (LLM timeout), Retry (fallback flashcards) | Z4-AC06, Z4-AC12, Z4-AC13 |
+| Validation HITL | Default (comprehension des actions) | Z3-AC02 a Z3-AC05 |
+| Dashboard parent | Empty (enfant pas commence), Stale (pas consulte depuis longtemps) | Z8-AC05, Z6-AC27 |

--- a/docs/ux/user-flow-complete.md
+++ b/docs/ux/user-flow-complete.md
@@ -1,0 +1,609 @@
+# User Flow complet -- Revise Mieux
+
+> Document UX principal. Couvre le defi produit, les personas, les 9 parcours, le flow ecran par ecran, le modele d'etats, les edge cases, les principes UX pedagogiques, l'equilibre parent/eleve, les implications React Native, les decisions ouvertes et les recommandations finales.
+
+---
+
+## 1. Executive summary
+
+Revise Mieux transforme des photos de cahier en sessions de revision adaptatives pour les collegiens (11-15 ans), avec un dashboard parent integre. Le defi UX central est la **double adoption** : l'eleve decide d'ouvrir l'app chaque soir, le parent decide de payer et d'installer. Chaque decision de design doit satisfaire les deux audiences simultanement sans compromettre ni l'engagement de l'eleve ni la confiance du parent.
+
+Ce document detaille les 20 ecrans de l'app (8 existants, 12 a creer), les 9 parcours produit cles, les 11 etats d'affichage par ecran critique, et les 30 edge cases identifies. Il est directement exploitable par un developpeur React Native avec Expo Router.
+
+**Chiffres cles** :
+- 53 ACs couverts par le Lot 0 (33 P1 + 20 P2)
+- 171 ACs totaux repartis sur 8 zones
+- 4 chapitres pilotes (HG, SVT, Physique-Chimie)
+- Cible : premiere session reussie en < 3 minutes apres l'install
+
+---
+
+## 2. Defi UX produit : la double adoption
+
+### Pourquoi ce n'est PAS une app standard a audience unique
+
+La plupart des apps educatives ciblent soit l'eleve (Duolingo, Quizlet) soit le parent (Klassroom, Pronote). Revise Mieux doit convaincre les deux simultanement, dans des cadres temporels differents :
+
+- **L'eleve** ouvre l'app le soir, 10-15 min. Sa decision est repetee quotidiennement. Chaque session est un micro-choix : "est-ce que j'ouvre l'app ou je regarde TikTok ?" Le design doit donner envie, pas obliger.
+- **Le parent** ouvre l'app 1-2 fois par semaine, < 2 min. Sa decision est ponctuelle (installation, renouvellement). Il a besoin d'un signal fiable sans micro-management.
+
+### Tensions entre les deux audiences
+
+| L'eleve veut | Le parent veut | Tension |
+|-------------|---------------|---------|
+| Interface attractive, moderne | Interface serieuse, credible | Esthetique intergenerationnelle |
+| Pas de surveillance | Visibilite sur l'usage | Transparence vs autonomie |
+| Pas de culpabilisation | Alertes si inactivite | Notification vs bien-etre |
+| Recompenses implicites (progression) | Metriques explicites (scores) | Granularite du feedback |
+| Sessions courtes et optionnelles | Usage regulier et mesurable | Frequence vs liberte |
+
+### Risques d'adoption
+
+**Cote eleve** :
+- Friction dans les 30 premieres secondes -> desinstallation
+- Premier OCR echoue sans recovery -> "ca marche pas"
+- Sessions trop longues ou repetitives -> lassitude
+- Sentiment de surveillance parentale -> rejet emotionnel
+
+**Cote parent** :
+- Aucun signal pendant 6 jours -> oubli de l'app
+- Metriques incomprehensibles (UNKNOWN, FRAGILE) -> perte de confiance
+- Trop de notifications -> desactivation complete
+- Score gonfle sur QCM faciles -> fausse securite
+
+### Qu'est-ce qui fait revenir un collegien de 13 ans chaque soir ?
+
+1. **Previsibilite** : "Ce soir : 3 activites, ~15 min." L'engagement est defini, pas ouvert.
+2. **Progression visible** : des items qui passent de UNKNOWN a SOLID. Un % qui monte.
+3. **Permission de fermer** : l'ecran "Fini pour ce soir" dit explicitement "c'est assez".
+4. **Variete** : alternance des types de questions (MCQ, CLOZE, SHORT) et des matieres.
+5. **Pas de punition** : pas de streak, pas de regression par inactivite, pas de "tu as rate".
+
+### Qu'est-ce qui fait qu'un parent de 45 ans fait confiance ?
+
+1. **Preuve rapide** : digest anticipe J+2 avec temps de revision et matieres couvertes.
+2. **Honnetete** : score_confidence visible, mention des items en verification.
+3. **Engagement minimal** : notification "routine terminee" le soir + digest hebdo le dimanche.
+4. **Labels lisibles** : "Bien acquis" au lieu de "SOLID", "En cours d'apprentissage" au lieu de "FRAGILE".
+5. **Action concrete** : script 3 minutes avec 2-3 questions orales a poser.
+
+---
+
+## 3. Personas
+
+Voir le document dedie : [`docs/ux/personas.md`](personas.md)
+
+4 personas :
+- **Theo (13 ans, 4e)** : motive mais irregulier. Veut 10-15 min/soir, pas plus.
+- **Ines (11 ans, 6e)** : appliquee mais anxieuse. Besoin de reassurance et de "fini".
+- **Lucas (15 ans, 3e)** : desengage. Seuil de friction zero. 30 secondes pour prouver la valeur.
+- **Laurent (45 ans, pere)** : cherche un signal fiable sans micro-manager.
+
+---
+
+## 4. Parcours produit cles
+
+### Parcours 1 : Onboarding -- premiere connexion
+
+**Acteurs** : Eleve (+ parent potentiel)
+**Objectif** : Premiere session reussie en < 3 minutes
+**ACs** : Z8-AC01, Z8-AC02, Z8-AC04, Z8-AC08
+
+```
+Installation
+    |
+    v
+Dashboard vide + chapitre demo (Z8-AC01, Z8-AC02)
+    |
+    v
+Session demo evening_first (~3 min, 8 questions)
+    |
+    v
+Debrief : 6/8 -> transitions UNKNOWN -> FRAGILE
+    |
+    v
+Dashboard avec progression visible
+    |
+    v
+Capture premier vrai cours (quand l'eleve veut)
+    |
+    v
+Pipeline OCR (processing.tsx) -> chapitre cree
+    |
+    v
+evening_first sur vrai chapitre -> debrief -> invitation parent (Z8-AC07)
+```
+
+**Gains pedagogiques** : premier contact avec le rappel actif. L'eleve decouvre que repondre a des questions est plus efficace que relire.
+
+**Reduction d'effort** : 0 configuration requise. Pas d'emploi du temps, pas de matiere, pas de formulaire. Un seul tap "Charger le chapitre demo" et c'est parti.
+
+---
+
+### Parcours 2 : Capture J0
+
+**Acteurs** : Eleve
+**Objectif** : Transformer des photos de cahier en items revisables
+**ACs** : Z2-AC01 a AC10, Z5-AC11, Z8-AC04
+
+```
+Tab Capture -> prendre 1-30 photos
+    |
+    v
+(Optionnel) Saisie emploi du temps matiere (Z6-AC01)
+    |
+    v
+Processing screen (3 phases, Z8-AC04)
+    |
+    v
+    ├── Succes : chapitre cree -> carte de lecon avec items
+    |
+    └── Echec : ecran recovery (Z8-AC03)
+              ├── Reprendre les photos
+              ├── Essayer quand meme
+              └── Chapitre demo
+```
+
+**Gains pedagogiques** : le contenu de revision est le propre cours de l'eleve, pas un contenu generique. L'ancrage est plus fort car l'eleve reconnait ses notes.
+
+---
+
+### Parcours 3 : Dashboard eleve -- plan d'action quotidien
+
+**Acteurs** : Eleve
+**Objectif** : Savoir quoi faire maintenant en < 5 secondes
+**ACs** : Z7-AC01, Z7-AC02, Z7-AC04, Z7-AC05, Z7-AC08, Z6-AC30
+
+```
+Ouverture de l'app (17h-22h)
+    |
+    v
+Dashboard soiree :
+  "Bonsoir Hugo ! Ce soir : 3 activites, ~15 min."
+    |
+    v
+  [C'est parti !]  ou  [Je n'ai pas beaucoup de temps]
+    |                    |
+    v                    v
+  Plan complet          Mode express (~10 min)
+    |                    |
+    v                    v
+  Completion progressive des etapes
+    |
+    v
+  Ecran de cloture : "Bravo ! Soiree terminee en 14 min."
+  -> notification parent "routine terminee"
+```
+
+**Reduction d'anxiete** : l'estimation de duree et l'ecran de cloture encadrent l'effort. L'eleve sait quand il commence et quand il finit.
+
+---
+
+### Parcours 4 : Session de revision
+
+**Acteurs** : Eleve
+**Objectif** : Repondre a des questions, recevoir du feedback, progresser
+**ACs** : Z1-AC01 a AC12, Z4-AC04 a AC09, Z6-AC05
+
+```
+Lancer une session
+    |
+    v
+Question affichee (MCQ / SHORT / CLOZE / NUMERIC)
+    |
+    v
+Reponse + Valider
+    |
+    v
+    ├── MCQ : scoring automatique
+    └── Autres : auto-evaluation "Je savais / Je ne savais pas"
+    |
+    v
+Feedback enrichi (reponse correcte + ce qui manquait + indice)
+    |
+    v
+    ├── Transition positive ? -> micro-celebration
+    └── Question suivante
+    |
+    v
+Debrief : score, progressions, item prioritaire a revoir
+```
+
+**Gains pedagogiques** : rappel actif (repondre > relire). Feedback immediat avec explication. Alternance de formats pour activer differents circuits cognitifs.
+
+---
+
+### Parcours 5 : Revue des erreurs
+
+**Acteurs** : Eleve
+**Objectif** : Comprendre ce qui a ete rate, pas juste constater
+**ACs** : Z4-AC09, Z1-AC19, Z1-AC21
+
+Le feedback enrichi (Z4-AC09) apres chaque reponse incorrecte contient 3 elements :
+1. La reponse correcte
+2. Ce qui manquait (specifique au type de question)
+3. Un indice pour la prochaine fois (1 phrase max)
+
+L'eleve peut aussi :
+- "Voir ma lecon" (Z1-AC21) pour le contexte complet
+- "Je ne comprends pas la question" (Z1-AC22) pour une reformulation
+
+Apres 3 echecs consecutifs sur le meme item, la difficulte descend automatiquement (Z1-AC19).
+
+---
+
+### Parcours 6 : Retour apres absence (3-7 jours)
+
+**Acteurs** : Eleve
+**Objectif** : Reprendre sans etre submerge
+**ACs** : Z6-AC13, Z6-AC22, Z6-AC21
+
+```
+Ouverture apres 5 jours d'absence
+    |
+    v
+Message : "Content de te revoir ! On reprend doucement."
+    |
+    v
+Session "retour en douceur" :
+  - 5 min max
+  - 4-6 items les plus anciens en retard
+  - Gabarits difficulte 1-2
+    |
+    v
+Debrief : "Bon retour ! Les points restants arrivent demain."
+    |
+    v
+Items restants etales sur 3-5 jours
+```
+
+**Principes critiques** : aucune regression par inactivite (Z6-AC13). Pas de streak. Pas de culpabilisation. Le message d'accueil est neutre ou positif.
+
+---
+
+### Parcours 7 : Dashboard parent
+
+**Acteurs** : Parent
+**Objectif** : Comprendre ce que fait l'app, verifier l'utilite
+**ACs** : Z6-AC27, Z6-AC29, Z6-AC30, Z8-AC05
+
+```
+Premier acces apres liaison (code 6 caracteres)
+    |
+    v
+Onboarding 3 ecrans (30s) :
+  1. "Voici ce que fait [Prenom]"
+  2. "Votre tableau de bord"
+  3. "Restez informe sans effort"
+    |
+    v
+Dashboard parent :
+  - Maitrise globale (% items OK+SOLID)
+  - Chapitres par matiere avec barres
+  - Activite de la semaine
+  - Script 3 minutes
+  - Validations en attente (si mode actif)
+```
+
+**Labels traduits** (Z6-AC29) :
+- UNKNOWN -> "Pas encore vu"
+- FRAGILE -> "En cours d'apprentissage"
+- OK -> "Compris, a consolider"
+- SOLID -> "Bien acquis"
+- validation_required -> "En verification"
+
+---
+
+### Parcours 8 : Validation HITL
+
+**Acteurs** : Eleve ou parent
+**Objectif** : Valider les items incertains generes par le LLM
+**ACs** : Z3-AC01 a AC06
+
+```
+Bandeau sur le chapitre : "6 zones a verifier"
+    |
+    v
+Ecran validation : item + suggestion IA
+    |
+    v
+    ├── Confirmer -> confidence boostee, cache invalidee
+    ├── Corriger -> contenu mis a jour, confidence = 1.0
+    ├── Je ne sais pas -> delegue a l'admin, item en mode simple
+    └── Ignorer -> item exclu des sessions, recuperable plus tard
+```
+
+**Point critique** : le chapitre est TOUJOURS utilisable meme si 0 validations faites (Z3-AC06). La validation est encouragee mais jamais bloquante.
+
+---
+
+### Parcours 9 : Gestion de contenu OCR incomplet
+
+**Acteurs** : Eleve, systeme
+**Objectif** : Continuer a travailler malgre des pages problematiques
+**ACs** : Z2-AC01, Z2-AC02, Z2-AC04, Z2-AC05, Z2-AC11
+
+```
+Pipeline OCR avec 10 pages
+    |
+    v
+Pages 1-3 traitees, 4-10 en cours
+    |
+    v
+Carte de lecon affiche les items des pages 1-3 (Z2-AC01)
+    + indicateur "3/10 pages analysees"
+    |
+    v
+Page 4 timeout -> badge "Zone illisible page 4" (Z2-AC02)
+Page 5 = 0 items -> marquee no_items_extracted (Z2-AC04)
+Page 6 = erreur LLM -> badge "Exercices non generes page 6" + bouton Reessayer (Z2-AC11)
+    |
+    v
+L'eleve peut lancer le diagnostic sur les items disponibles
+Le chapitre N'EST PAS bloque
+```
+
+---
+
+## 5. Flow detaille ecran par ecran
+
+Voir le document dedie : [`docs/ux/screen-inventory.md`](screen-inventory.md)
+
+**Resume** : 20 ecrans au total.
+- 8 existants : Dashboard, Capture, Settings, Onboarding, Processing, Chapter detail, Session, Debrief
+- 12 a creer : Validation HITL, Recovery OCR, Creation exam, Emploi du temps, Invitation parent, Dashboard parent, Onboarding parent, Angles morts, Fiche PDF, Report papier, Cloture soiree, Controle blanc
+
+---
+
+## 6. Modele d'etats par ecran critique
+
+Voir le document dedie : [`docs/ux/state-model.md`](state-model.md)
+
+11 etats couverts pour 8 ecrans critiques : Default, Loading, Processing, Success, Empty, Partial, Stale, OCR Uncertainty, Error, Blocked, Retry.
+
+---
+
+## 7. Edge cases et chemins de recuperation
+
+Voir le document dedie : [`docs/ux/edge-cases.md`](edge-cases.md)
+
+30 edge cases repartis en 6 categories : Capture photo (6), Session de revision (7), Validation HITL (4), Adoption et engagement (6), Connectivite (3), Cas limites techniques (4).
+
+---
+
+## 8. Principes UX pedagogiques
+
+### Principe 1 : Rappel actif > relecture
+
+Toute session genere des questions. L'eleve ne relit jamais passivement. Meme le mode fallback (LLM indisponible, Z4-AC12) utilise des flashcards avec "Je savais / Je ne savais pas".
+
+**Implication design** : pas d'ecran de "lecture de la lecon" comme activite principale. Le bouton "Voir ma lecon" (Z1-AC21) est contextuel (pendant une question), pas un mode de revision.
+
+### Principe 2 : Repetition espacee invisible
+
+L'algorithme SRS (UNKNOWN -> FRAGILE -> OK -> SOLID avec next_due_at) est entierement transparent pour l'eleve. Il ne voit pas les intervalles, les dates, les algorithmes. Il voit : "Ce soir : 3 activites, ~15 min."
+
+**Implication design** : jamais montrer next_due_at a l'eleve. Le dashboard soiree presente un plan, pas un calendrier de revision.
+
+### Principe 3 : Espacement obligatoire pour SOLID
+
+La transition OK -> SOLID exige 2 reussites espacees de 24h minimum (Z1-AC03/AC04). L'eleve ne peut pas "grinder" un item en SOLID en une seule session.
+
+**Implication design** : message explicatif quand l'espacement bloque la progression : "Bonne reponse ! Reviens demain pour verrouiller ce point -- ton cerveau a besoin d'une nuit pour bien memoriser."
+
+### Principe 4 : Double codage (Paivio)
+
+Les blocs visuels du cahier (schemas, graphiques, tableaux) sont preserves et reutilises dans les questions (Z2-AC15, Z4-AC17). L'eleve voit le schema de son cahier dans le quiz.
+
+**Implication design** : les questions visuelles affichent l'image au-dessus du texte, avec zoom plein ecran (Z2-AC18). Placeholder aux dimensions exactes pour eviter le reflow.
+
+### Principe 5 : Growth mindset dans tous les messages
+
+Aucun message ne dit "echec", "regression", "tu as perdu". Les regressions sont framed comme "refresh", "a revoir", "pas encore acquis" (Z1-AC05, Z1-AC06, Z1-AC26).
+
+**Implication design** : fichier de strings centralise avec review systematique du framing. Chaque message negatif doit etre reformule en action future positive.
+
+### Principe 6 : Pas de streak, pas de gamification punitive
+
+L'app ne compte pas les jours consecutifs (Z6-AC15). Pas de mecanique de type "tu as perdu ta serie de 7 jours". La seule recompense est la progression de maitrise (UNKNOWN -> SOLID).
+
+**Implication design** : les micro-celebrations (Z1-AC14) portent sur les transitions de maitrise, pas sur la regularite. Le debrief valorise ce qui a progresse, pas combien de jours d'affilee.
+
+---
+
+## 9. Principes d'equilibre parent/eleve
+
+### Ce que le parent DOIT voir
+
+- Maitrise globale par chapitre (% items OK+SOLID)
+- Frequence de revision (sessions/semaine, temps total)
+- Alertes risque reel : inactivite 3+ jours, controle dans 3 jours avec items FRAGILE
+- Qualite du signal : score_confidence, items en verification
+
+### Ce que le parent NE DOIT PAS dominer
+
+- Le detail question par question (l'eleve a droit a l'intimite de ses erreurs)
+- Le temps exact de chaque session (le parent n'est pas un chrono)
+- Les regressions individuelles (le parent voit les tendances, pas les micro-echecs)
+- L'emploi du temps modifie (l'eleve gere, le parent est notifie si opt-in)
+
+### Comment l'eleve percoit la presence du parent
+
+- **Invisible au quotidien** : l'eleve ne voit JAMAIS "ton parent a ete prevenu" (Z6-AC17 note). La notification parent est unidirectionnelle.
+- **Presente a 2 moments** : (1) l'invitation initiale apres la premiere session, (2) les ValidationTasks si le parent est en mode actif (max 3/semaine).
+- **Percue comme un allie, pas un flic** : le script 3 minutes est un moment de discussion parent-enfant autour du cours, pas un interrogatoire.
+
+### Design principles pour l'intergenerationnel
+
+1. **Pas enfantin** : pas de mascottes, pas d'etoiles, pas de confettis excessifs. Les micro-celebrations sont des messages textuels + animations subtiles.
+2. **Pas froid** : le tutoiement (eleve), les messages personalises avec prenom, le ton encourageant.
+3. **Pas bureaucratique** : le parent voit des barres de couleur et des % lisibles, pas des tableaux Excel.
+4. **Deux niveaux de lecture** : le meme score "72% maitrise" est lisible par l'eleve (barre de couleur) et par le parent (% numerique + label "Compris, a consolider").
+
+---
+
+## 10. Implications pour l'implementation React Native
+
+### Liste des ecrans et routes Expo Router
+
+Voir [`docs/ux/screen-inventory.md`](screen-inventory.md) pour la liste complete.
+
+### Logique de navigation
+
+```
+Root (_layout.tsx)
+├── (tabs)/
+│   ├── index.tsx          -- Dashboard eleve
+│   ├── capture.tsx        -- Capture photo
+│   └── settings.tsx       -- Parametres
+├── onboarding.tsx         -- Onboarding eleve
+├── processing.tsx         -- Pipeline OCR
+├── recovery.tsx           -- Recovery OCR       (a creer)
+├── chapter/[id].tsx       -- Detail chapitre
+├── session/[id].tsx       -- Session revision
+├── validation/[id].tsx    -- Validation HITL    (a creer)
+├── exam/create.tsx        -- Creation exam      (a creer)
+├── schedule.tsx           -- Emploi du temps    (a creer)
+├── invite-parent.tsx      -- Invitation parent  (a creer)
+├── blind-spots.tsx        -- Angles morts       (a creer)
+├── paper-report/[id].tsx  -- Report papier      (a creer)
+└── parent/                                      (a creer)
+    ├── dashboard.tsx      -- Dashboard parent
+    └── onboarding.tsx     -- Onboarding parent
+```
+
+### Etat partage : Context vs local vs TanStack Query (prevu)
+
+| Donnee | Ou vit l'etat | Justification |
+|--------|---------------|---------------|
+| Token JWT / auth | React Context (global) | Necessaire partout |
+| User profile (prenom, zone) | React Context (global) | Utilise dans les messages personnalises |
+| Liste des chapitres | TanStack Query (cache serveur) | Rafraichi par pull-to-refresh, invalide apres upload |
+| Masteries | TanStack Query (cache serveur) | Invalide apres chaque session |
+| EveningPlan | Etat local du dashboard | Calcule a chaque ouverture, ephemere |
+| Session en cours | Etat local de session/[id].tsx | Specifique a un ecran |
+| Photos capturees | Etat local de capture.tsx | Pas de persistence entre navigations |
+| Reponses pending_sync | AsyncStorage (persistance locale) | Survit au kill de l'app |
+
+### Patterns reutilisables
+
+| Composant | Usage | Props cles |
+|-----------|-------|-----------|
+| `EmptyState` | Dashboard vide, 0 validations, 0 items | `icon`, `title`, `subtitle`, `ctaLabel`, `onCta` |
+| `ErrorState` | Erreur reseau sur tout ecran | `message`, `onRetry` |
+| `LoadingSkeleton` | Placeholder pendant chargement | `variant` (card, list, bar) |
+| `MasteryBar` | Barre de maitrise (existant) | `breakdown`, `height`, `showLabel` |
+| `MasteryBadge` | Badge etat d'un item (existant) | `state` |
+| `FeedbackCard` | Feedback post-reponse | `isCorrect`, `expected`, `missing`, `hint` |
+| `MicroCelebration` | Animation transition positive | `fromState`, `toState`, `term` |
+| `ProgressSteps` | Checklist etapes (onboarding, plan soiree) | `steps[]`, `currentIndex` |
+| `ProcessingPhase` | Phase 1/2/3 du pipeline | `phase`, `progress` |
+
+### Types TypeScript (props majeurs)
+
+```typescript
+// EveningPlan
+type EveningStep = {
+  type: 'capture' | 'evening_first' | 'daily' | 'pre_class';
+  subject_label: string;
+  estimated_duration_min: number;
+  status: 'pending' | 'in_progress' | 'completed' | 'skipped';
+  session_id?: string;
+};
+
+type EveningPlan = {
+  steps: EveningStep[];
+  total_duration_min: number;
+  mode: 'full' | 'express';
+  completed_at?: string;
+};
+
+// Feedback
+type FeedbackData = {
+  is_correct: boolean;
+  expected_answer: string;
+  missing_elements?: string[];
+  hint: string;
+  transition?: {
+    from_state: MasteryState;
+    to_state: MasteryState;
+    term: string;
+  };
+};
+
+// Validation
+type ValidationAction = 'confirm' | 'correct' | 'skip' | 'ignore';
+
+type ValidationTask = {
+  id: string;
+  item_id: string;
+  suggestion: string;
+  source: 'fidelity_check' | 'coherence_check' | 'student_report' | 'anomaly_detection';
+  status: 'PENDING' | 'RESOLVED_CONFIRMED' | 'RESOLVED_CORRECTED' | 'DEFERRED_BY_STUDENT' | 'IGNORED_BY_STUDENT';
+};
+
+// Parent dashboard
+type ParentChapterSummary = {
+  id: string;
+  name: string;
+  subject: string;
+  mastery_pct: number;           // % items OK+SOLID
+  validation_pending_count: number;
+  mastery_label: string;         // "Bien acquis", "En cours d'apprentissage"
+};
+
+type ParentDigest = {
+  sessions_count: number;
+  total_revision_min: number;
+  chapters: ParentChapterSummary[];
+  alerts: string[];
+  next_action: string;
+};
+```
+
+---
+
+## 11. Decisions produit ouvertes
+
+Voir le document dedie : [`docs/ux/open-decisions.md`](open-decisions.md)
+
+11 decisions identifiees, dont 3 bloquantes pour le Lot 0 P2 :
+1. App unique vs separee pour le parent
+2. Auto-evaluation vs scoring automatique MCQ
+3. Position du bouton "Ajouter des pages"
+
+---
+
+## 12. Recommandations UX finales
+
+### R1 : Prioriser le "Time to First Quiz" (TTFQ)
+
+Le chapitre demo (Z8-AC01) est le meilleur investissement UX du Lot 0. Un eleve qui fait son premier quiz en 3 minutes a 5x plus de chances de revenir le lendemain. Le TTFQ doit etre mesure et optimise comme metrique produit primaire.
+
+### R2 : Le plan de soiree est le produit
+
+Le dashboard soiree (Z7-AC02) n'est pas une feature -- c'est l'interface principale. L'eleve ne devrait jamais avoir a decider quoi faire. Le plan decide pour lui. L'estimation de duree et l'ecran de cloture sont les deux extremites du "contrat" avec l'eleve.
+
+### R3 : Investir dans le feedback enrichi (Z4-AC09) avant tout le reste
+
+Un feedback qui dit "Faux -- la bonne reponse est X" n'enseigne rien. Le feedback enrichi (reponse correcte + ce qui manquait + indice 1 phrase) est le micro-moment d'apprentissage le plus puissant de chaque session. Il doit etre templatise (pas LLM en temps reel) pour garantir la rapidite (< 200 ms).
+
+### R4 : Tester le mode express (Z7-AC08) des la premiere semaine
+
+Le mode "Je n'ai pas beaucoup de temps" est un anti-churn majeur. 5 minutes de revision ciblee valent infiniment mieux que 0 minute. Si l'eleve ne voit pas ce bouton, il saute la revision entierement les soirs charges.
+
+### R5 : La notification "routine terminee" est le killer feature parent
+
+Le parent qui recoit "Theo a termine sa revision du soir : 3 matieres, 14 min" chaque soir n'a pas besoin d'ouvrir l'app. C'est le signal de confiance maximal avec le cout minimal. Implementer Z7-AC13 le plus tot possible.
+
+### R6 : Ne jamais montrer un ecran vide
+
+Chaque ecran a un empty state explicite avec un CTA. Le dashboard vide a le chapitre demo. La session sans items a le message "Bravo, tu es a jour". Le dashboard parent sans activite a "Vous serez notifie des la premiere session". Aucun ecran ne doit laisser l'utilisateur face a du vide sans action possible.
+
+### R7 : Mesurer le taux d'echec du premier OCR
+
+L'echec du premier OCR (Z8-AC03) est le point de churn #1 du funnel. Logger chaque `j0_first_upload_recovery` et monitorer le taux. Si > 20% des premiers uploads echouent, c'est un probleme systeme, pas un probleme utilisateur.
+
+### R8 : Implementer la persistance locale des reponses (Z6-AC31) tot
+
+Un collegien utilise l'app dans le bus, en zone blanche, avec du wifi instable. Une deconnexion de 10 secondes ne doit jamais perdre une reponse. La persistance optimiste cote client est un prerequis pour toute session fiable en mobilite.


### PR DESCRIPTION
## Summary

- Documentation UX complete pour l'app mobile Revise Mieux couvrant les deux audiences (eleve 11-15 ans + parent)
- 6 livrables structures tracant vers les 171 ACs (Z1 a Z8) et les 53 ACs Lot 0
- Analyse des 8 ecrans existants + identification des 12 ecrans manquants

## Livrables

| Fichier | Contenu |
|---------|---------|
| `docs/ux/user-flow-complete.md` | Document principal : defi produit, 9 parcours, principes UX pedagogiques, equilibre parent/eleve, implications React Native, recommandations |
| `docs/ux/personas.md` | 4 personas detailles (Theo 13 ans, Ines 11 ans, Lucas 15 ans, Laurent 45 ans) avec etats emotionnels et matrice d'interactions |
| `docs/ux/screen-inventory.md` | Inventaire des 20 ecrans avec route Expo Router, intention UX, CTA, donnees, mapping ACs et wireframes textuels |
| `docs/ux/state-model.md` | 11 etats d'affichage (default, loading, processing, success, empty, partial, stale, OCR uncertainty, error, blocked, retry) pour 8 ecrans critiques |
| `docs/ux/edge-cases.md` | 30 edge cases en 6 categories (capture, session, HITL, adoption, connectivite, technique) avec risque UX, traitement et recovery |
| `docs/ux/open-decisions.md` | 11 decisions produit a prendre avant implementation, dont 3 bloquantes pour le Lot 0 P2 |

## Questions ouvertes (arbitrage humain requis)

1. **OD-01** : App unique avec switch profil parent ou app parent separee ?
2. **OD-02** : Auto-evaluation vs scoring automatique MCQ des le Lot 0 ?
3. **OD-03** : Bouton "Ajouter des pages" sur la carte chapitre, dans le tab capture, ou les deux ?

## Test plan

- [ ] Relire chaque ecran de `screen-inventory.md` et verifier que le mapping AC est complet
- [ ] Valider les wireframes textuels avec les ecrans existants dans `mobile/app/`
- [ ] Trancher les 3 decisions ouvertes haute priorite avant de coder les ecrans manquants
- [ ] Verifier la coherence des types TypeScript proposes avec les DTOs existants dans `services/api.ts`

Generated with [Claude Code](https://claude.com/claude-code)