### PR TITLE
docs: corriger tracker Z2-AC15/Z4-AC17 (fixes #21)

### DIFF
--- a/docs/lot0-tracker.md
+++ b/docs/lot0-tracker.md
@@ -24,7 +24,7 @@
 |---|---|---|---|---|
 | 0.1 | PRD, ACs, MVP-scope | `[x]` | — | `docs/PRD.md`, `docs/ac/Z*.md`, `docs/MVP-scope.md` |
 | 0.2 | Schéma SQL initial (migration 001) | `[x]` | — | `backend/migrations/001_initial_schema.sql` |
-| 0.3 | Ajout `visual_blocks` et refs visuelles | `[x]` | Z2-AC15/16/17/18, Z4-AC17 (schéma prêt, implémentation MVP Hardening) | migration 001 mise à jour |
+| 0.3 | Ajout `visual_blocks` et refs visuelles | `[~]` | Z2-AC15/16/17/18, Z4-AC17 (schéma prêt, implémentation différée MVP Hardening) | migration 001 mise à jour |
 
 ---
 


### PR DESCRIPTION
## Summary

- Corrige le statut de la tâche 0.3 dans `docs/lot0-tracker.md` : `[x]` -> `[~]`
- Z2-AC15 et Z4-AC17 sont classées MVP Hardening dans `docs/MVP-scope.md` — seul le schéma SQL (table `visual_blocks`) est prêt, pas l'implémentation
- Ajoute la mention "implémentation différée" dans la note existante

## Test plan

- [ ] Vérifier que la tâche 0.3 affiche `[~]` avec la note "(schéma prêt, implémentation différée MVP Hardening)"
- [ ] Vérifier la cohérence avec `docs/MVP-scope.md` (Z2-AC15 et Z4-AC17 = MVP Hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)