### PR TITLE
feat: ajouter provider mistral-small pour IDP

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -94,6 +94,17 @@ func main() {
 		} else {
 			log.Println("WARNING: GOOGLE_AI_API_KEY not set — LLM structuration disabled")
 		}
+	case "mistral":
+		if cfg.MistralAPIKey != "" {
+			llmStructurer = openaicompat.NewStructurer(
+				"https://api.mistral.ai/v1",
+				cfg.MistralAPIKey,
+				cfg.MistralStructModel,
+			)
+			log.Printf("LLM structurer initialized: provider=mistral model=%s", cfg.MistralStructModel)
+		} else {
+			log.Println("WARNING: MISTRAL_API_KEY not set — LLM structuration disabled")
+		}
 	default:
 		log.Printf("WARNING: unknown LLM_PROVIDER %q — LLM structuration disabled", cfg.LLMProvider)
 	}
@@ -115,6 +126,15 @@ func main() {
 		}
 	case "anthropic":
 		// TODO: implement anthropic scorer if needed
+	case "mistral":
+		if cfg.MistralAPIKey != "" {
+			scorer = openaicompat.NewAnswerScorer(
+				"https://api.mistral.ai/v1",
+				cfg.MistralAPIKey,
+				cfg.MistralStructModel,
+			)
+			log.Printf("Answer scorer initialized: provider=mistral model=%s", cfg.MistralStructModel)
+		}
 	}
 
 	// --- Application Services ---

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	S3SecretKey string
 	S3Region    string
 
-	// LLM provider selection: "gemini" (default), "anthropic"
+	// LLM provider selection: "gemini" (default), "anthropic", "mistral"
 	LLMProvider string
 
 	// Anthropic LLM
@@ -32,6 +32,10 @@ type Config struct {
 	// Google Gemini LLM
 	GoogleAIAPIKey   string
 	GeminiStructModel string // Model for structuration (default: gemini-2.5-flash)
+
+	// Mistral LLM
+	MistralAPIKey     string
+	MistralStructModel string // Model for structuration (default: mistral-small-latest)
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -57,6 +61,9 @@ func Load() (*Config, error) {
 
 		GoogleAIAPIKey:    envOrDefault("GOOGLE_AI_API_KEY", ""),
 		GeminiStructModel: envOrDefault("GEMINI_STRUCT_MODEL", "gemini-2.5-flash"),
+
+		MistralAPIKey:      envOrDefault("MISTRAL_API_KEY", ""),
+		MistralStructModel: envOrDefault("MISTRAL_STRUCT_MODEL", "mistral-small-latest"),
 	}
 
 	if cfg.JWTSecret == "" {


### PR DESCRIPTION
## Summary

- Ajoute le case `"mistral"` dans le switch `LLM_PROVIDER` de `main.go`, utilisant `openaicompat.NewStructurer()` avec l'endpoint `https://api.mistral.ai/v1`
- Ajoute `MISTRAL_API_KEY` et `MISTRAL_STRUCT_MODEL` (defaut: `mistral-small-latest`) dans la config
- Ajoute aussi le scorer Mistral pour la notation automatique des reponses textuelles
- Le provider par defaut reste `gemini` -- aucun changement de comportement existant

Fixes #16

## Test plan

- [x] `go build ./...` passe
- [x] `go test ./... -count=1` -- tous les tests passent, zero regression
- [ ] Tester manuellement avec `LLM_PROVIDER=mistral MISTRAL_API_KEY=... go run ./cmd/server`
- [ ] Verifier les logs: `LLM structurer initialized: provider=mistral model=mistral-small-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)