### PR TITLE
test(domain): improve coverage chapter and session

### DIFF
--- a/backend/internal/domain/chapter/chapter_test.go
+++ b/backend/internal/domain/chapter/chapter_test.go
@@ -2,6 +2,10 @@ package chapter
 
 import (
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/popul/revisemieux/internal/domain/event"
 )
 
 // Z5-AC01: canonical identity key for items
@@ -66,3 +70,333 @@ func TestZ5AC01_CanonicalKey_NilPackID(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// --- Test helpers ---
+
+var testIDGen = event.UUIDv7Generator{}
+
+// --- BlockType Value Object ---
+
+func TestBlockType_Valid(t *testing.T) {
+	tests := []struct {
+		name  string
+		bt    BlockType
+		valid bool
+	}{
+		{"TEXT", BlockText, true},
+		{"PHOTO", BlockPhoto, true},
+		{"SCHEMA", BlockSchema, true},
+		{"MAP", BlockMap, true},
+		{"GRAPH", BlockGraph, true},
+		{"TABLE", BlockTable, true},
+		{"CIRCUIT", BlockCircuit, true},
+		{"DECORATIVE", BlockDecorative, true},
+		{"invalid empty", BlockType(""), false},
+		{"invalid unknown", BlockType("UNKNOWN"), false},
+		{"invalid lowercase", BlockType("text"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.bt.Valid(); got != tt.valid {
+				t.Errorf("BlockType(%q).Valid() = %v, want %v", tt.bt, got, tt.valid)
+			}
+		})
+	}
+}
+
+// --- ItemType Value Object ---
+
+func TestItemType_Valid(t *testing.T) {
+	tests := []struct {
+		name  string
+		it    ItemType
+		valid bool
+	}{
+		{"KNOWLEDGE", ItemKnowledge, true},
+		{"PROCEDURE", ItemProcedure, true},
+		{"DOCUMENT", ItemDocument, true},
+		{"WRITING", ItemWriting, true},
+		{"invalid empty", ItemType(""), false},
+		{"invalid unknown", ItemType("QUIZ"), false},
+		{"invalid lowercase", ItemType("knowledge"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.it.Valid(); got != tt.valid {
+				t.Errorf("ItemType(%q).Valid() = %v, want %v", tt.it, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestParseItemType_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  ItemType
+	}{
+		{"KNOWLEDGE", ItemKnowledge},
+		{"PROCEDURE", ItemProcedure},
+		{"DOCUMENT", ItemDocument},
+		{"WRITING", ItemWriting},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseItemType(tt.input)
+			if err != nil {
+				t.Fatalf("ParseItemType(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseItemType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseItemType_Invalid(t *testing.T) {
+	tests := []string{"", "QUIZ", "knowledge", "invalid"}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseItemType(input)
+			if err == nil {
+				t.Errorf("ParseItemType(%q) expected error, got nil", input)
+			}
+		})
+	}
+}
+
+// --- NewChapter constructor ---
+
+func TestNewChapter_FieldsInitialized(t *testing.T) {
+	userID := uuid.Must(uuid.NewV7())
+	now := time.Now()
+
+	ch := NewChapter(testIDGen, userID, "Physique", "4e", "Chapitre 1 - Forces", now)
+
+	if ch.ID == uuid.Nil {
+		t.Error("ID should not be nil")
+	}
+	if ch.UserID != userID {
+		t.Errorf("UserID = %v, want %v", ch.UserID, userID)
+	}
+	if ch.Subject != "Physique" {
+		t.Errorf("Subject = %q, want %q", ch.Subject, "Physique")
+	}
+	if ch.ClassLevel != "4e" {
+		t.Errorf("ClassLevel = %q, want %q", ch.ClassLevel, "4e")
+	}
+	if ch.Name != "Chapitre 1 - Forces" {
+		t.Errorf("Name = %q, want %q", ch.Name, "Chapitre 1 - Forces")
+	}
+	if ch.Archived {
+		t.Error("new chapter should not be archived")
+	}
+	if ch.IsDemo {
+		t.Error("new chapter should not be demo")
+	}
+	if ch.CurrentRevisionID != nil {
+		t.Error("new chapter should have no current revision")
+	}
+	if ch.PackID != nil {
+		t.Error("new chapter should have no pack ID")
+	}
+	if !ch.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt = %v, want %v", ch.CreatedAt, now)
+	}
+	if !ch.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt = %v, want %v", ch.UpdatedAt, now)
+	}
+}
+
+// --- Item Archive / Unarchive ---
+
+func TestItem_Archive(t *testing.T) {
+	item := &Item{
+		ID:        uuid.Must(uuid.NewV7()),
+		Archived:  false,
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	now := time.Now()
+
+	item.Archive(now)
+
+	if !item.Archived {
+		t.Error("item should be archived after Archive()")
+	}
+	if !item.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt should be updated to %v, got %v", now, item.UpdatedAt)
+	}
+}
+
+func TestItem_Unarchive(t *testing.T) {
+	item := &Item{
+		ID:        uuid.Must(uuid.NewV7()),
+		Archived:  true,
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	now := time.Now()
+
+	item.Unarchive(now)
+
+	if item.Archived {
+		t.Error("item should not be archived after Unarchive()")
+	}
+	if !item.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt should be updated to %v, got %v", now, item.UpdatedAt)
+	}
+}
+
+func TestItem_ArchiveThenUnarchive(t *testing.T) {
+	item := &Item{ID: uuid.Must(uuid.NewV7()), Archived: false}
+	now := time.Now()
+
+	item.Archive(now)
+	if !item.Archived {
+		t.Fatal("should be archived")
+	}
+
+	later := now.Add(time.Minute)
+	item.Unarchive(later)
+	if item.Archived {
+		t.Fatal("should be unarchived")
+	}
+	if !item.UpdatedAt.Equal(later) {
+		t.Errorf("UpdatedAt = %v, want %v", item.UpdatedAt, later)
+	}
+}
+
+// --- Exam ---
+
+func TestNewExam_FieldsInitialized(t *testing.T) {
+	userID := uuid.Must(uuid.NewV7())
+	ch1 := uuid.Must(uuid.NewV7())
+	ch2 := uuid.Must(uuid.NewV7())
+	now := time.Now()
+	examDate := now.Add(7 * 24 * time.Hour)
+
+	exam := NewExam(testIDGen, userID, "Controle Forces", examDate, []uuid.UUID{ch1, ch2}, now)
+
+	if exam.ID == uuid.Nil {
+		t.Error("ID should not be nil")
+	}
+	if exam.UserID != userID {
+		t.Errorf("UserID = %v, want %v", exam.UserID, userID)
+	}
+	if exam.Title != "Controle Forces" {
+		t.Errorf("Title = %q, want %q", exam.Title, "Controle Forces")
+	}
+	if !exam.ExamDate.Equal(examDate) {
+		t.Errorf("ExamDate = %v, want %v", exam.ExamDate, examDate)
+	}
+	if len(exam.ChapterIDs) != 2 {
+		t.Fatalf("ChapterIDs length = %d, want 2", len(exam.ChapterIDs))
+	}
+	if exam.ChapterIDs[0] != ch1 || exam.ChapterIDs[1] != ch2 {
+		t.Errorf("ChapterIDs = %v, want [%v, %v]", exam.ChapterIDs, ch1, ch2)
+	}
+}
+
+func TestExam_AddChapter(t *testing.T) {
+	exam := &Exam{
+		ID:         uuid.Must(uuid.NewV7()),
+		ChapterIDs: []uuid.UUID{uuid.Must(uuid.NewV7())},
+		UpdatedAt:  time.Now().Add(-time.Hour),
+	}
+	newCh := uuid.Must(uuid.NewV7())
+	now := time.Now()
+
+	exam.AddChapter(newCh, now)
+
+	if len(exam.ChapterIDs) != 2 {
+		t.Fatalf("expected 2 chapters, got %d", len(exam.ChapterIDs))
+	}
+	if exam.ChapterIDs[1] != newCh {
+		t.Errorf("second chapter = %v, want %v", exam.ChapterIDs[1], newCh)
+	}
+	if !exam.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt should be updated")
+	}
+}
+
+func TestExam_AddChapter_AlreadyLinked(t *testing.T) {
+	ch := uuid.Must(uuid.NewV7())
+	oldTime := time.Now().Add(-time.Hour)
+	exam := &Exam{
+		ID:         uuid.Must(uuid.NewV7()),
+		ChapterIDs: []uuid.UUID{ch},
+		UpdatedAt:  oldTime,
+	}
+
+	exam.AddChapter(ch, time.Now())
+
+	if len(exam.ChapterIDs) != 1 {
+		t.Errorf("should not duplicate: got %d chapters", len(exam.ChapterIDs))
+	}
+	// UpdatedAt should NOT change since nothing was added
+	if !exam.UpdatedAt.Equal(oldTime) {
+		t.Error("UpdatedAt should not change when chapter already linked")
+	}
+}
+
+func TestExam_RemoveChapter(t *testing.T) {
+	ch1 := uuid.Must(uuid.NewV7())
+	ch2 := uuid.Must(uuid.NewV7())
+	exam := &Exam{
+		ID:         uuid.Must(uuid.NewV7()),
+		ChapterIDs: []uuid.UUID{ch1, ch2},
+		UpdatedAt:  time.Now().Add(-time.Hour),
+	}
+	now := time.Now()
+
+	exam.RemoveChapter(ch1, now)
+
+	if len(exam.ChapterIDs) != 1 {
+		t.Fatalf("expected 1 chapter, got %d", len(exam.ChapterIDs))
+	}
+	if exam.ChapterIDs[0] != ch2 {
+		t.Errorf("remaining chapter = %v, want %v", exam.ChapterIDs[0], ch2)
+	}
+	if !exam.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt should be updated")
+	}
+}
+
+func TestExam_RemoveChapter_NotFound(t *testing.T) {
+	ch := uuid.Must(uuid.NewV7())
+	oldTime := time.Now().Add(-time.Hour)
+	exam := &Exam{
+		ID:         uuid.Must(uuid.NewV7()),
+		ChapterIDs: []uuid.UUID{ch},
+		UpdatedAt:  oldTime,
+	}
+
+	exam.RemoveChapter(uuid.Must(uuid.NewV7()), time.Now())
+
+	if len(exam.ChapterIDs) != 1 {
+		t.Errorf("should not remove anything: got %d chapters", len(exam.ChapterIDs))
+	}
+	if !exam.UpdatedAt.Equal(oldTime) {
+		t.Error("UpdatedAt should not change when chapter not found")
+	}
+}
+
+func TestExam_DaysUntil(t *testing.T) {
+	tests := []struct {
+		name     string
+		examDate time.Time
+		from     time.Time
+		want     int
+	}{
+		{"7 days", time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC), time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC), 7},
+		{"0 days same day", time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC), time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC), 0},
+		{"past exam", time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC), -2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exam := &Exam{ExamDate: tt.examDate}
+			got := exam.DaysUntil(tt.from)
+			if got != tt.want {
+				t.Errorf("DaysUntil() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/domain/session/scoring_test.go
+++ b/backend/internal/domain/session/scoring_test.go
@@ -1,7 +1,12 @@
 package session
 
 import (
+	"math"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/popul/revisemieux/internal/domain/event"
 )
 
 // Z1-AC10 — RUBRIC scoring
@@ -141,5 +146,406 @@ func TestZ1AC10_Binary_Incorrect(t *testing.T) {
 	r := ScoreBinary(false)
 	if r.Score != 0.0 || r.Class != ClassFailure {
 		t.Errorf("got score=%f class=%q, want 0.0/failure", r.Score, r.Class)
+	}
+}
+
+// --- Scoring edge cases ---
+
+func TestScoreRubric_ZeroTotal_Failure(t *testing.T) {
+	r := ScoreRubric(0, 0)
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want %q for 0/0", r.Class, ClassFailure)
+	}
+	if r.Score != 0 {
+		t.Errorf("score: got %f, want 0 for 0/0", r.Score)
+	}
+}
+
+func TestScoreNumeric_NaN_Failure(t *testing.T) {
+	r := ScoreNumeric(math.NaN(), 42, 0.1, "m", "m", false, false)
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want failure for NaN expected", r.Class)
+	}
+}
+
+func TestScoreNumeric_Inf_Failure(t *testing.T) {
+	r := ScoreNumeric(math.Inf(1), 42, 0.1, "m", "m", false, false)
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want failure for Inf expected", r.Class)
+	}
+}
+
+func TestScoreNumeric_ExpectedZero_ExactMatch(t *testing.T) {
+	r := ScoreNumeric(0, 0, 0.1, "m", "m", false, false)
+	if r.Class != ClassSuccess {
+		t.Errorf("class: got %q, want success for 0==0", r.Class)
+	}
+}
+
+func TestScoreNumeric_ExpectedZero_NonZeroActual(t *testing.T) {
+	r := ScoreNumeric(0, 5, 0.1, "m", "m", false, false)
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want failure for 0 vs 5", r.Class)
+	}
+}
+
+func TestScoreNumeric_ValueOutOfTolerance_Failure(t *testing.T) {
+	// 20% off with 10% tolerance
+	r := ScoreNumeric(100, 120, 0.10, "m", "m", false, false)
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want failure (20%% > 10%% tolerance)", r.Class)
+	}
+}
+
+func TestScoreKeywords_EmptyExpected_Failure(t *testing.T) {
+	r := ScoreKeywords([]string{}, []string{"anything"})
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want failure for empty expected", r.Class)
+	}
+}
+
+func TestScoreKeywords_EmptyFound_Failure(t *testing.T) {
+	r := ScoreKeywords([]string{"chloroplaste"}, []string{})
+	if r.Class != ClassFailure {
+		t.Errorf("class: got %q, want failure (0/1)", r.Class)
+	}
+	if r.Score != 0 {
+		t.Errorf("score: got %f, want 0", r.Score)
+	}
+}
+
+func TestScoreKeywords_WhitespaceTrimmed(t *testing.T) {
+	expected := []string{"  chloroplaste  "}
+	found := []string{"chloroplaste"}
+	r := ScoreKeywords(expected, found)
+	if r.Score != 1.0 {
+		t.Errorf("score: got %f, want 1.0 (whitespace should be trimmed)", r.Score)
+	}
+}
+
+// --- SessionType Value Object ---
+
+func TestSessionType_Valid(t *testing.T) {
+	tests := []struct {
+		name  string
+		st    SessionType
+		valid bool
+	}{
+		{"daily", TypeDaily, true},
+		{"diagnostic", TypeDiagnostic, true},
+		{"mock_exam", TypeMockExam, true},
+		{"evening_first", TypeEveningFirst, true},
+		{"pre_class", TypePreClass, true},
+		{"invalid empty", SessionType(""), false},
+		{"invalid unknown", SessionType("UNKNOWN"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.st.Valid(); got != tt.valid {
+				t.Errorf("SessionType(%q).Valid() = %v, want %v", tt.st, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestParseSessionType_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  SessionType
+	}{
+		{"daily", TypeDaily},
+		{"diagnostic", TypeDiagnostic},
+		{"mock_exam", TypeMockExam},
+		{"evening_first", TypeEveningFirst},
+		{"pre_class", TypePreClass},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSessionType(tt.input)
+			if err != nil {
+				t.Fatalf("ParseSessionType(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseSessionType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSessionType_Invalid(t *testing.T) {
+	tests := []string{"", "UNKNOWN", "Daily", "invalid"}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseSessionType(input)
+			if err == nil {
+				t.Errorf("ParseSessionType(%q) expected error, got nil", input)
+			}
+		})
+	}
+}
+
+// --- SessionStatus Value Object ---
+
+func TestSessionStatus_Valid(t *testing.T) {
+	tests := []struct {
+		name  string
+		ss    SessionStatus
+		valid bool
+	}{
+		{"COMPOSING", StatusComposing, true},
+		{"IN_PROGRESS", StatusInProgress, true},
+		{"COMPLETED", StatusCompleted, true},
+		{"EXPIRED", StatusExpired, true},
+		{"ABANDONED", StatusAbandoned, true},
+		{"invalid empty", SessionStatus(""), false},
+		{"invalid unknown", SessionStatus("DRAFT"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ss.Valid(); got != tt.valid {
+				t.Errorf("SessionStatus(%q).Valid() = %v, want %v", tt.ss, got, tt.valid)
+			}
+		})
+	}
+}
+
+// --- NewSession constructor ---
+
+var testIDGen = event.UUIDv7Generator{}
+
+func TestNewSession_FieldsInitialized(t *testing.T) {
+	userID := uuid.Must(uuid.NewV7())
+	now := time.Now()
+
+	s := NewSession(testIDGen, userID, TypeDaily, TriggerManual, now)
+
+	if s.ID == uuid.Nil {
+		t.Error("ID should not be nil")
+	}
+	if s.UserID != userID {
+		t.Errorf("UserID = %v, want %v", s.UserID, userID)
+	}
+	if s.SessionType != TypeDaily {
+		t.Errorf("SessionType = %q, want %q", s.SessionType, TypeDaily)
+	}
+	if s.Status != StatusComposing {
+		t.Errorf("Status = %q, want %q", s.Status, StatusComposing)
+	}
+	if s.TriggerType != TriggerManual {
+		t.Errorf("TriggerType = %q, want %q", s.TriggerType, TriggerManual)
+	}
+	if s.StartedAt != nil {
+		t.Error("StartedAt should be nil for new session")
+	}
+	if s.CompletedAt != nil {
+		t.Error("CompletedAt should be nil for new session")
+	}
+	if s.CurrentQuestionIndex != 0 {
+		t.Errorf("CurrentQuestionIndex = %d, want 0", s.CurrentQuestionIndex)
+	}
+	if !s.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt = %v, want %v", s.CreatedAt, now)
+	}
+}
+
+// --- Session state transitions ---
+
+func TestSession_Start_FromComposing(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	now := time.Now()
+
+	err := s.Start(now)
+
+	if err != nil {
+		t.Fatalf("Start() unexpected error: %v", err)
+	}
+	if s.Status != StatusInProgress {
+		t.Errorf("Status = %q, want %q", s.Status, StatusInProgress)
+	}
+	if s.StartedAt == nil || !s.StartedAt.Equal(now) {
+		t.Errorf("StartedAt = %v, want %v", s.StartedAt, now)
+	}
+}
+
+func TestSession_Start_FromInProgress_Error(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	_ = s.Start(time.Now())
+
+	err := s.Start(time.Now())
+
+	if err != ErrSessionNotResumable {
+		t.Errorf("Start() from IN_PROGRESS should return ErrSessionNotResumable, got %v", err)
+	}
+}
+
+func TestSession_Start_FromCompleted_Error(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	_ = s.Start(time.Now())
+	_ = s.Complete(time.Now())
+
+	err := s.Start(time.Now())
+
+	if err != ErrSessionNotResumable {
+		t.Errorf("Start() from COMPLETED should return ErrSessionNotResumable, got %v", err)
+	}
+}
+
+func TestSession_Complete_FromInProgress(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	_ = s.Start(time.Now())
+	now := time.Now()
+
+	err := s.Complete(now)
+
+	if err != nil {
+		t.Fatalf("Complete() unexpected error: %v", err)
+	}
+	if s.Status != StatusCompleted {
+		t.Errorf("Status = %q, want %q", s.Status, StatusCompleted)
+	}
+	if s.CompletedAt == nil || !s.CompletedAt.Equal(now) {
+		t.Errorf("CompletedAt = %v, want %v", s.CompletedAt, now)
+	}
+}
+
+func TestSession_Complete_FromComposing_Error(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+
+	err := s.Complete(time.Now())
+
+	if err != ErrSessionNotCompletable {
+		t.Errorf("Complete() from COMPOSING should return ErrSessionNotCompletable, got %v", err)
+	}
+}
+
+func TestSession_Resume_FromInProgress(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	_ = s.Start(time.Now())
+
+	err := s.Resume()
+
+	if err != nil {
+		t.Fatalf("Resume() unexpected error: %v", err)
+	}
+}
+
+func TestSession_Resume_FromComposing_Error(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+
+	err := s.Resume()
+
+	if err != ErrSessionNotResumable {
+		t.Errorf("Resume() from COMPOSING should return ErrSessionNotResumable, got %v", err)
+	}
+}
+
+func TestSession_Resume_FromCompleted_Error(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	_ = s.Start(time.Now())
+	_ = s.Complete(time.Now())
+
+	err := s.Resume()
+
+	if err != ErrSessionNotResumable {
+		t.Errorf("Resume() from COMPLETED should return ErrSessionNotResumable, got %v", err)
+	}
+}
+
+func TestSession_Abandon(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	_ = s.Start(time.Now())
+	now := time.Now()
+
+	s.Abandon(now)
+
+	if s.Status != StatusAbandoned {
+		t.Errorf("Status = %q, want %q", s.Status, StatusAbandoned)
+	}
+	if !s.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt = %v, want %v", s.UpdatedAt, now)
+	}
+}
+
+func TestSession_Abandon_FromComposing(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDaily, TriggerManual, time.Now())
+	now := time.Now()
+
+	s.Abandon(now)
+
+	if s.Status != StatusAbandoned {
+		t.Errorf("Status = %q, want %q", s.Status, StatusAbandoned)
+	}
+}
+
+func TestSession_FullLifecycle_Composing_InProgress_Completed(t *testing.T) {
+	s := NewSession(testIDGen, uuid.Must(uuid.NewV7()), TypeDiagnostic, TriggerScheduled, time.Now())
+	if s.Status != StatusComposing {
+		t.Fatalf("initial status = %q, want COMPOSING", s.Status)
+	}
+
+	if err := s.Start(time.Now()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.Status != StatusInProgress {
+		t.Fatalf("after Start, status = %q, want IN_PROGRESS", s.Status)
+	}
+
+	if err := s.Complete(time.Now()); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if s.Status != StatusCompleted {
+		t.Fatalf("after Complete, status = %q, want COMPLETED", s.Status)
+	}
+}
+
+// --- NewAttempt constructor ---
+
+func TestNewAttempt_FieldsInitialized(t *testing.T) {
+	sessionID := uuid.Must(uuid.NewV7())
+	questionID := uuid.Must(uuid.NewV7())
+	userID := uuid.Must(uuid.NewV7())
+	answer := []byte(`{"choice":"A"}`)
+	now := time.Now()
+
+	a := NewAttempt(testIDGen, sessionID, questionID, userID, answer, 1.0, now)
+
+	if a.ID == uuid.Nil {
+		t.Error("ID should not be nil")
+	}
+	if a.SessionID != sessionID {
+		t.Errorf("SessionID = %v, want %v", a.SessionID, sessionID)
+	}
+	if a.QuestionID != questionID {
+		t.Errorf("QuestionID = %v, want %v", a.QuestionID, questionID)
+	}
+	if a.UserID != userID {
+		t.Errorf("UserID = %v, want %v", a.UserID, userID)
+	}
+	if a.Score != 1.0 {
+		t.Errorf("Score = %f, want 1.0", a.Score)
+	}
+	if a.Source != AttemptInteractive {
+		t.Errorf("Source = %q, want %q", a.Source, AttemptInteractive)
+	}
+	if !a.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt = %v, want %v", a.CreatedAt, now)
+	}
+	if a.HintUsed {
+		t.Error("HintUsed should default to false")
+	}
+	if a.RapidResponse {
+		t.Error("RapidResponse should default to false")
+	}
+}
+
+// --- PackConstraints ---
+
+func TestDefaultPackConstraints(t *testing.T) {
+	pc := DefaultPackConstraints()
+	if pc.MaxWritingPerSession != 1 {
+		t.Errorf("MaxWritingPerSession = %d, want 1", pc.MaxWritingPerSession)
+	}
+	if !pc.SessionMustIncludeDoc {
+		t.Error("SessionMustIncludeDoc should be true")
 	}
 }


### PR DESCRIPTION
## Summary
- **chapter domain**: 30% → 100% coverage — added tests for `BlockType.Valid`, `ItemType.Valid`, `ParseItemType`, `NewChapter`, `Item.Archive/Unarchive`, `NewExam`, `Exam.AddChapter/RemoveChapter/DaysUntil`
- **session domain**: 52.7% → 100% coverage — added tests for `SessionType.Valid`, `ParseSessionType`, `SessionStatus.Valid`, `NewSession`, all state transitions (`Start`, `Resume`, `Complete`, `Abandon`), `NewAttempt`, `DefaultPackConstraints`, and scoring edge cases (NaN, Inf, zero total, empty keywords)
- All 133+ existing tests continue to pass

Fixes #31, fixes #32

## Test plan
- [x] `go test ./internal/domain/chapter/... -cover` → 100%
- [x] `go test ./internal/domain/session/... -cover` → 100%
- [x] `go test ./... -count=1` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)