### PR TITLE
design: appliquer le design system mobile (fixes #46)

### DIFF
--- a/mobile/components/MasteryBar.tsx
+++ b/mobile/components/MasteryBar.tsx
@@ -1,4 +1,5 @@
-import { View as RNView, Text as RNText } from 'react-native';
+import { useRef, useEffect } from 'react';
+import { View as RNView, Text as RNText, Animated, Easing } from 'react-native';
 import { masteryColors } from '@/constants/Colors';
 import { useColors } from '@/components/Themed';
 import { typography, spacing, radius } from '@/constants/Typography';
@@ -14,6 +15,13 @@ type Props = {
   breakdown: MasteryBreakdown;
   height?: number;
   showLabel?: boolean;
+};
+
+export const masteryLabels: Record<string, string> = {
+  unknown: 'Nouveau',
+  fragile: 'En cours',
+  ok: 'Compris',
+  solid: 'Acquis',
 };
 
 export function MasteryBar({ breakdown, height = 10, showLabel = true }: Props) {
@@ -43,13 +51,10 @@ export function MasteryBar({ breakdown, height = 10, showLabel = true }: Props) 
         }}
       >
         {segments.map((seg) => (
-          <RNView
+          <AnimatedSegment
             key={seg.key}
-            style={{
-              width: `${(seg.value / total) * 100}%`,
-              height: '100%',
-              backgroundColor: seg.color,
-            }}
+            widthPct={(seg.value / total) * 100}
+            color={seg.color}
           />
         ))}
       </RNView>
@@ -59,6 +64,39 @@ export function MasteryBar({ breakdown, height = 10, showLabel = true }: Props) 
         </RNText>
       )}
     </RNView>
+  );
+}
+
+type AnimatedSegmentProps = {
+  widthPct: number;
+  color: string;
+};
+
+function AnimatedSegment({ widthPct, color }: AnimatedSegmentProps) {
+  const animValue = useRef(new Animated.Value(widthPct)).current;
+
+  useEffect(() => {
+    Animated.timing(animValue, {
+      toValue: widthPct,
+      duration: 200,
+      easing: Easing.ease,
+      useNativeDriver: false,
+    }).start();
+  }, [widthPct, animValue]);
+
+  const widthStyle = animValue.interpolate({
+    inputRange: [0, 100],
+    outputRange: ['0%', '100%'],
+  });
+
+  return (
+    <Animated.View
+      style={{
+        width: widthStyle,
+        height: '100%',
+        backgroundColor: color,
+      }}
+    />
   );
 }
 

--- a/mobile/constants/Colors.ts
+++ b/mobile/constants/Colors.ts
@@ -8,6 +8,12 @@ const palette = {
   orangeLight: '#FFF3E0',
   red: '#FF3B30',
   redLight: '#FFEBEE',
+  secondary: '#7C5CFC',
+  secondaryLight: '#EDE8FF',
+  ambre: '#F5A623',
+  ambreLight: '#FFF8E1',
+  greenRich: '#2ECC71',
+  greenRichLight: '#E8F8F0',
   gray50: '#FAFAFA',
   gray100: '#F5F5F5',
   gray200: '#EEEEEE',
@@ -23,10 +29,10 @@ const palette = {
 };
 
 export const masteryColors = {
-  unknown: palette.gray400,
-  fragile: palette.orange,
+  unknown: palette.gray500,
+  fragile: palette.ambre,
   ok: palette.blue,
-  solid: palette.green,
+  solid: palette.greenRich,
 };
 
 export default {

--- a/mobile/constants/Typography.ts
+++ b/mobile/constants/Typography.ts
@@ -1,7 +1,8 @@
 import { TextStyle } from 'react-native';
 
 export const typography: Record<string, TextStyle> = {
-  h1: { fontSize: 28, fontWeight: '700', lineHeight: 34 },
+  display: { fontSize: 36, fontWeight: '700', lineHeight: 44 },
+  h1: { fontSize: 32, fontWeight: '700', lineHeight: 40 },
   h2: { fontSize: 22, fontWeight: '700', lineHeight: 28 },
   h3: { fontSize: 18, fontWeight: '600', lineHeight: 24 },
   body: { fontSize: 16, fontWeight: '400', lineHeight: 22 },
@@ -9,6 +10,13 @@ export const typography: Record<string, TextStyle> = {
   caption: { fontSize: 14, fontWeight: '400', lineHeight: 18 },
   captionBold: { fontSize: 14, fontWeight: '600', lineHeight: 18 },
   small: { fontSize: 12, fontWeight: '400', lineHeight: 16 },
+  label: {
+    fontSize: 14,
+    fontWeight: '700' as const,
+    lineHeight: 18,
+    textTransform: 'uppercase' as const,
+    letterSpacing: 0.5,
+  },
 };
 
 export const spacing = {


### PR DESCRIPTION
## Summary

- **Colors.ts** : ajout palette `secondary`, `ambre`, `greenRich` + variantes light ; mise a jour de `masteryColors` (unknown -> gray500, fragile -> ambre, solid -> greenRich) pour meilleur contraste et dissociation du warning systeme
- **Typography.ts** : ajout tokens `display` (36px hero) et `label` (14px uppercase + letterSpacing) ; h1 passe de 28px a 32px
- **MasteryBar.tsx** : segments animes via `Animated.timing` (200ms ease) ; export `masteryLabels` eleve (Nouveau, En cours, Compris, Acquis)

## Test plan

- [x] `cd mobile && npx jest --verbose` : 106 tests pass, 0 failures
- [ ] Verifier visuellement les nouvelles couleurs mastery sur iOS/Android
- [ ] Confirmer que l'animation de transition des segments est fluide (200ms)
- [ ] Verifier l'accessibilite des contrastes (UNKNOWN gris plus fonce, FRAGILE ambre vs warning)

## Refs

- `docs/design/color-system.md` — justifications couleurs
- `docs/design/typography.md` — echelle typographique

🤖 Generated with [Claude Code](https://claude.com/claude-code)