### PR TITLE
docs: README principal + decisions UX (fixes #53, fixes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,145 @@
-# Révise Mieux
+![CI](https://github.com/popul/ReviseMieux/actions/workflows/ci.yml/badge.svg?branch=reboot)
 
-Assistant de révision personnalisé pour collégiens (11–15 ans), propulsé par l'IA.
+# Revise Mieux
 
-**Révise Mieux** transforme des photos de cahier (manuscrit, schémas, documents) en entraînements adaptatifs : carte de leçon structurée, exercices en rappel actif avec répétition espacée, contrôles blancs, et reporting parent basé sur des preuves de maîtrise.
+Revise Mieux est un SaaS educatif qui transforme des photos de cahier en assistant de revision personnalise pour collegiens (11-15 ans). A partir d'un upload de cours, le produit genere une carte de lecon structuree, des entrainements adaptatifs avec repetition espacee, et met les parents dans la boucle via un reporting base sur des preuves de maitrise. Le projet est en phase Lot 0 (pre-MVP) avec 53 criteres d'acceptation sur 4 chapitres pilotes.
 
-## Statut du projet
+**Documentation complete** : [https://popul.github.io/ReviseMieux/](https://popul.github.io/ReviseMieux/)
 
-Le dépôt contient actuellement les **spécifications complètes** du produit. L'implémentation n'a pas encore démarré.
+---
+
+## Stack technique
+
+| Composant | Technologie |
+|-----------|-------------|
+| Backend API | Go 1.23 + Gin |
+| Base de donnees | PostgreSQL 16 (pgx/v5, SQL brut) |
+| Mobile | React Native + Expo 54 + Expo Router |
+| LLM / OCR | Gemini Flash / mistral-small |
+| Cache | Redis (go-redis/v9) |
+| Storage | S3 / MinIO |
+
+---
+
+## Quick start
+
+**Prerequis** : Go 1.23+, Node.js 20+, Docker (pour PostgreSQL + Redis + MinIO)
+
+```bash
+git clone https://github.com/popul/ReviseMieux.git
+make setup
+make dev
+```
+
+---
+
+## Architecture
+
+Monorepo `backend/` (Go) + `mobile/` (Expo), architecture hexagonale avec 4 bounded contexts DDD.
+
+```mermaid
+graph TB
+    subgraph "Driving Adapters"
+        HTTP["HTTP Handlers<br/>(Gin)"]
+        CLI["CLI / Tests"]
+    end
+
+    subgraph "Application Services"
+        PS["PipelineService"]
+        MS["MasteryService"]
+        SS["SessionService"]
+        VS["ValidationService"]
+    end
+
+    subgraph "Domain (zero dependance externe)"
+        subgraph "Capture"
+            CH["Chapter"]
+            IT["Item / Notion / Block"]
+        end
+        subgraph "Mastery"
+            MA["Mastery"]
+            TR["Transitions<br/>UNKNOWN → FRAGILE → OK → SOLID"]
+        end
+        subgraph "Session"
+            SE["Session"]
+            QA["Questions / Attempts"]
+        end
+        subgraph "Validation"
+            VT["ValidationTask"]
+            HI["HITL Actions"]
+        end
+    end
+
+    subgraph "Driven Adapters"
+        PG["PostgreSQL<br/>(pgx/v5)"]
+        RD["Redis"]
+        S3["S3 / MinIO"]
+        LLM["Gemini Flash<br/>mistral-small"]
+    end
+
+    HTTP --> PS & MS & SS & VS
+    CLI --> PS & MS & SS & VS
+    PS --> CH & IT
+    MS --> MA & TR
+    SS --> SE & QA
+    VS --> VT & HI
+    CH -.->|"ports<br/>(interfaces)"| PG
+    MA -.->|"ports"| PG
+    SE -.->|"ports"| PG & RD
+    VT -.->|"ports"| PG
+    PS -.->|"ports"| S3 & LLM
+```
+
+Le domaine definit les **ports** (interfaces). Les adaptateurs les implementent. Les dependances pointent toujours vers l'interieur.
+
+---
+
+## Etat du projet
+
+| Metrique | Valeur |
+|----------|--------|
+| Tests backend | 326 |
+| Tests mobile | 106 |
+| Coverage backend | 44.7% |
+| ACs Lot 0 | 53 (33 P1 + 20 P2) |
+
+---
+
+## Design system
+
+Le design system interactif (HTML) est disponible dans le repo :
+
+- Fichier : [`docs/design/design-system.html`](docs/design/design-system.html)
+- En ligne : [https://popul.github.io/ReviseMieux/design/design-system.html](https://popul.github.io/ReviseMieux/design/design-system.html)
+
+---
+
+## Commandes utiles
+
+| Commande | Description |
+|----------|-------------|
+| `make test` | Lancer tous les tests (backend + mobile) |
+| `make dev` | Demarrer l'environnement de developpement |
+| `make docs-serve` | Servir la documentation localement |
+| `/feedback-loop` | Cycle autonome Claude Code : fix CI + feedback |
+| `/sprint` | Cycle autonome : selection issue -> implementation -> CI |
+| `/backlog` | Gestion du backlog GitHub Issues |
+
+---
 
 ## Documentation
 
 | Document | Description |
-|---|---|
-| [PRD](docs/PRD.md) | Product Requirements Document complet — personas, parcours, pipeline, architecture, modèle de données, algorithmes, SLA |
-| [MVP Scope](docs/MVP-scope.md) | Classification des 171 critères d'acceptation (MVP Core / Hardening / Post-MVP) et périmètre Lot 0 |
-| [Critères d'acceptation](docs/ac/README.md) | 171 ACs en format Given/When/Then, répartis en 8 zones |
+|----------|-------------|
+| [PRD](docs/PRD.md) | Product Requirements Document complet |
+| [MVP Scope](docs/MVP-scope.md) | 171 ACs classifies, perimetre Lot 0 |
+| [Lot 0 Tracker](docs/lot0-tracker.md) | Suivi d'implementation |
+| [Criteres d'acceptation](docs/ac/README.md) | 171 ACs en Given/When/Then (8 zones) |
+| [Decisions UX](docs/ux/open-decisions.md) | Decisions produit documentees |
+| [CLAUDE.md](CLAUDE.md) | Conventions et regles de developpement |
 
-### Zones de critères d'acceptation
-
-| Zone | Sujet | ACs |
-|---|---|---|
-| [Z1](docs/ac/Z1.md) | Transitions Mastery & répétition espacée | 28 |
-| [Z2](docs/ac/Z2.md) | Pipeline J0 — erreurs & timeouts | 18 |
-| [Z3](docs/ac/Z3.md) | Validation HITL (Human-in-the-loop) | 17 |
-| [Z4](docs/ac/Z4.md) | Lazy generation, concurrence & cache | 17 |
-| [Z5](docs/ac/Z5.md) | Versioning chapitre & identité item | 11 |
-| [Z6](docs/ac/Z6.md) | Emploi du temps, notifications & engagement parent | 46 |
-| [Z7](docs/ac/Z7.md) | Routine de soirée & orchestration | 26 |
-| [Z8](docs/ac/Z8.md) | Onboarding & première utilisation | 8 |
-
-## Chapitres pilotes (MVP)
-
-| Matière | Chapitre | Pack |
-|---|---|---|
-| Histoire-Géographie | Les inégalités dans le monde | HG-INEG |
-| Histoire-Géographie | La société féodale | HG-FEOD |
-| SVT | La photosynthèse | SVT-PHOTO |
-| Physique-Chimie | Masse, volume et densité | PC-MVD |
-
-## Stack cible
-
-| Composant | Technologie |
-|---|---|
-| API | Node.js ou Go |
-| OCR & Vision | Python (workers async) |
-| LLM | Anthropic Claude API |
-| Base de données | PostgreSQL |
-| Cache | Redis |
-| File de messages | BullMQ / SQS |
-| Stockage | S3 |
-| Frontend | React / React Native (mobile-first) |
+---
 
 ## Licence
 
-Projet privé — tous droits réservés.
+MIT

--- a/docs/ux/open-decisions.md
+++ b/docs/ux/open-decisions.md
@@ -1,6 +1,6 @@
-# Decisions produit ouvertes -- Revise Mieux
+# Decisions produit -- Revise Mieux
 
-> Decisions qui necessitent un arbitrage humain avant l'implementation. Classees par impact et urgence.
+> Decisions produit et UX pour le Lot 0. Chaque decision est documentee avec son statut, sa justification et sa date.
 
 ---
 
@@ -8,14 +8,13 @@
 
 ### OD-01 : App unique ou app parent separee ?
 
+**Statut** : Decide -- 2026-04-03
+
 **Question** : Le parent utilise-t-il la meme app que l'eleve (avec un switch de profil) ou une app/PWA distincte ?
 
-**Options** :
-- **(A) Meme app, profil parent** : un compte parent dans la meme app Expo. Toggle entre les vues. Moins de friction a l'installation (un seul store listing). Risque : l'eleve percoit l'app comme "celle de mes parents".
-- **(B) App parent separee** : PWA ou app legere. Separation nette des audiences. L'eleve ne voit jamais l'interface parent. Cout : deux codebases a maintenir.
-- **(C) Meme app, acces parent via web** : le parent accede a un dashboard web. Zero installation supplementaire. Le lien est dans le digest email. Cout : developper un dashboard web.
+**Decision** : App unique, profil parent avec switch.
 
-**Recommandation** : Option (A) pour le Lot 0 avec un switch de profil clair. L'eleve ne doit jamais voir le dashboard parent par accident. Migrer vers (C) en post-MVP si le parent utilise principalement le digest.
+**Justification** : Simplifie le developpement, une seule codebase. Un seul store listing reduit la friction a l'installation. L'eleve ne voit jamais le dashboard parent grace au switch de profil. Migration possible vers dashboard web (option C) en post-MVP si le parent utilise principalement le digest.
 
 **Impact** : Architecture des routes Expo Router, strategie d'authentification, structure de navigation.
 
@@ -23,14 +22,13 @@
 
 ### OD-02 : Auto-evaluation vs scoring automatique en Lot 0
 
+**Statut** : Decide -- 2026-04-03
+
 **Question** : Le Lot 0 utilise l'auto-evaluation ("Je savais / Je ne savais pas") car le scoring LLM en temps reel n'est pas implemente. Quand basculer vers le scoring automatique ?
 
-**Options** :
-- **(A) Rester en auto-evaluation pour le Lot 0 entier** : simple, pas de dependance LLM en temps reel. Risque : l'eleve triche (surtout Lucas).
-- **(B) Scoring automatique MCQ des le Lot 0** : les MCQ ont une reponse deterministe, pas besoin de LLM. L'auto-evaluation reste pour les SHORT/KEYWORDS/RUBRIC.
-- **(C) Scoring LLM pour tout des le Lot 0** : experience complete mais dependance forte au LLM pendant les sessions.
+**Decision** : Scoring automatique sur tout (pas seulement MCQ), via LLM backend (Gemini Flash).
 
-**Recommandation** : Option (B). Les MCQ representent ~40% des questions en difficulte 1. Le scoring automatique des MCQ est trivial (comparaison de choix). L'auto-evaluation reste pour les questions ouvertes jusqu'au scoring LLM.
+**Justification** : Plus fiable que l'auto-evaluation. Le scoring LLM est disponible via Gemini Flash cote backend, ce qui elimine le risque de triche (surtout pour les eleves comme Lucas). Couvre 100% des types de questions (MCQ, SHORT, KEYWORDS, RUBRIC).
 
 **Impact** : Composant de session (affichage feedback), API submit answer, logique de scoring.
 
@@ -38,14 +36,13 @@
 
 ### OD-03 : Position du bouton "Ajouter des pages" dans la navigation
 
+**Statut** : Decide -- 2026-04-03
+
 **Question** : Le bouton "Ajouter des pages" (Z5-AC11) est-il sur la carte du chapitre, dans le tab capture, ou les deux ?
 
-**Options** :
-- **(A) Sur la carte du chapitre uniquement** : l'eleve qui veut ajouter va naturellement sur le chapitre. Coherent avec le contexte.
-- **(B) Dans le tab capture avec selection du chapitre** : l'eleve qui ouvre l'app pour capturer commence par le tab capture. Il choisit ensuite "Nouveau chapitre" ou "Ajouter a [chapitre existant]".
-- **(C) Les deux** : duplication de l'entree mais couverture maximale des comportements.
+**Decision** : Deux boutons "Ajouter des pages" (carte chapitre + tab capture).
 
-**Recommandation** : Option (C). Le bouton sur la carte du chapitre couvre le cas "je revise et je vois qu'il manque des pages". Le tab capture couvre le cas "j'ai pris des notes aujourd'hui, je veux les ajouter". Les deux sont des scenarios reels.
+**Justification** : Accessibilite maximale, les deux contextes sont naturels. Le bouton sur la carte du chapitre couvre le cas "je revise et je vois qu'il manque des pages". Le tab capture couvre le cas "j'ai pris des notes aujourd'hui, je veux les ajouter".
 
 **Impact** : Navigation capture, flow de selection de chapitre dans le tab capture.
 
@@ -55,14 +52,13 @@
 
 ### OD-04 : Moment d'affichage de la saisie d'emploi du temps
 
+**Statut** : Reporte -- 2026-04-03
+
 **Question** : Z6-AC01 specifie que la saisie d'emploi du temps apparait au premier upload d'une matiere. Est-ce le bon moment, ou est-ce trop tot (friction dans le flow de capture) ?
 
-**Options** :
-- **(A) Au premier upload (spec actuelle)** : contextuel, l'eleve sait quand il a cette matiere. Friction : interrompt le flow capture -> pipeline.
-- **(B) Apres la premiere session completee** : l'eleve a deja vecu la valeur. Moins de friction initiale.
-- **(C) Dans les parametres uniquement** : aucune interruption. Risque : personne ne le remplit jamais.
+**Decision** : Reporter -- pas d'emploi du temps en Lot 0.
 
-**Recommandation** : Option (A) avec un bouton "Plus tard" tres visible. Le moment est naturel ("tu viens de capturer ton cours de physique, quand as-tu physique ?"). Le mode degrade (Z6-AC11) protege contre le skip.
+**Justification** : PRD S11 est post-MVP. La saisie d'emploi du temps ajoute de la friction dans le flow de capture sans apporter de valeur immediate en Lot 0 (1 pere + 1 fils, usage local). Le mode degrade (Z6-AC11) couvre le cas ou l'emploi du temps n'est pas rempli.
 
 **Impact** : Flow de creation de chapitre, timing des ecrans intermediaires.
 
@@ -70,14 +66,13 @@
 
 ### OD-05 : Presentation des regressions dans le debrief
 
+**Statut** : Decide -- 2026-04-03
+
 **Question** : Quand un item regresse (SOLID -> OK, OK -> FRAGILE), faut-il le montrer dans le debrief ou le masquer ?
 
-**Options** :
-- **(A) Montrer avec framing positif** : "Ce point a besoin d'un refresh -- on le revoit bientot." Transparent mais potentiellement anxiogene (Ines).
-- **(B) Masquer les regressions** : le debrief ne montre que les progressions positives. L'eleve decouvre la regression dans le dashboard. Risque : sentiment de tromperie.
-- **(C) Montrer uniquement si l'eleve est en mode "detail"** : debrief minimal (score + progressions), bouton "Voir le detail" pour les regressions.
+**Decision** : Ton neutre pour les regressions ("A revoir", pas de rouge).
 
-**Recommandation** : Option (C). Le debrief reste positif par defaut (progressions uniquement). L'eleve curieux peut voir le detail. Le framing growth mindset s'applique dans le detail.
+**Justification** : Growth mindset, ne pas decourager l'eleve. Le debrief reste positif par defaut (progressions uniquement). Le framing growth mindset s'applique quand le detail est consulte. Pas de signaux visuels anxiogenes (rouge, croix, alertes).
 
 **Impact** : Composant debrief, structure de la reponse API debrief.
 
@@ -85,14 +80,13 @@
 
 ### OD-06 : Nombre de notifications parent par defaut
 
+**Statut** : Decide -- 2026-04-04
+
 **Question** : Quelles notifications parent sont activees par defaut a la liaison ?
 
-**Options** :
-- **(A) Tout active** : routine terminee, session manquee, inactivite, changement EDT. Risque : trop de bruit, le parent desactive tout.
-- **(B) Minimal** : uniquement routine terminee + digest hebdo. Le parent active le reste si il veut.
-- **(C) Progressive** : semaine 1 = routine terminee uniquement. Semaine 2 = ajout digest. Semaine 3 = ajout alertes inactivite.
+**Decision** : 1 notification parent/semaine (digest).
 
-**Recommandation** : Option (B). Le signal positif (routine terminee) et le digest hebdo couvrent 80% du besoin. Les alertes negatives (session manquee, inactivite) sont opt-in pour eviter l'alert fatigue.
+**Justification** : Pas de spam en Lot 0, le parent consulte quand il veut. Le signal positif (routine terminee) et le digest hebdo couvrent 80% du besoin. Les alertes negatives (session manquee, inactivite) sont opt-in pour eviter l'alert fatigue.
 
 **Impact** : ParentNotificationPref defaults, ecran de preferences parent.
 
@@ -100,64 +94,80 @@
 
 ### OD-07 : Traitement du chapitre demo apres le premier upload
 
+**Statut** : Decide -- 2026-04-03
+
 **Question** : Z8-AC01 specifie que le chapitre demo est archive automatiquement quand le premier vrai chapitre produit >= 1 item. Faut-il le supprimer ou l'archiver ?
 
-**Options** :
-- **(A) Archiver (masquer du dashboard)** : le chapitre demo reste en base, les masteries demo sont conservees. L'eleve peut le retrouver dans les parametres.
-- **(B) Supprimer** : nettoyage complet. Pas de pollution en base.
+**Decision** : Garder le chapitre demo visible, marque "Demo", suppressible.
 
-**Recommandation** : Option (A). L'archivage est non-destructif. Si l'eleve veut revenir au chapitre demo (rare mais possible), il peut.
+**Justification** : L'eleve peut le supprimer, mais il reste comme reference. L'archivage est non-destructif. Si l'eleve veut revenir au chapitre demo (rare mais possible), il peut. Le marquage "Demo" evite la confusion avec les vrais chapitres.
 
 **Impact** : Logique d'archivage, filtre dashboard.
 
 ---
 
-## Priorite basse (post-MVP mais a documenter)
+## Priorite basse (post-MVP mais documente)
 
 ### OD-08 : Gestion multi-enfants pour le parent
 
+**Statut** : Reporte -- 2026-04-03
+
 **Question** : Un parent avec 2 enfants dans l'app (ex: Theo en 4e et sa soeur en 6e) voit-il un dashboard unifie ou deux dashboards separes ?
 
-**Recommandation** : Dashboard avec un selecteur d'enfant en haut. Notifications distinctes par enfant (Z6-AC39). A specifier en detail post-MVP.
+**Decision** : Reporter multi-enfants au MVP.
+
+**Justification** : Lot 0 = 1 pere + 1 fils. Le multi-enfants introduit de la complexite (selecteur d'enfant, notifications distinctes par enfant Z6-AC39) sans valeur pour le cas d'usage Lot 0. A specifier en detail post-MVP.
 
 ---
 
 ### OD-09 : Partage de contenu entre eleves
 
+**Statut** : Reporte -- 2026-04-03
+
 **Question** : Deux eleves de la meme classe peuvent-ils partager un chapitre (eviter le double OCR) ?
 
-**Recommandation** : Hors scope Lot 0. Le partage introduit des problemes de propriete des masteries, de RGPD, et d'integrite pedagogique. A evaluer en phase 2.
+**Decision** : Reporter partage entre eleves.
+
+**Justification** : Hors scope Lot 0 et MVP. Le partage introduit des problemes de propriete des masteries, de RGPD, et d'integrite pedagogique. A evaluer en phase 2.
 
 ---
 
 ### OD-10 : Localisation (langues autres que le francais)
 
+**Statut** : Reporte -- 2026-04-03
+
 **Question** : L'app est entierement en francais. Faut-il prevoir l'internationalisation des le depart ?
 
-**Recommandation** : Non pour le Lot 0. Les messages de feedback (growth mindset, debrief) sont trop culturellement specifiques pour etre traduits mecaniquement. Structurer le code pour i18n (fichiers de strings, pas de texte en dur dans les composants) mais ne pas investir dans les traductions.
+**Decision** : Reporter localisation (francais uniquement).
+
+**Justification** : MVP = marche francais. Les messages de feedback (growth mindset, debrief) sont trop culturellement specifiques pour etre traduits mecaniquement. Structurer le code pour i18n (fichiers de strings, pas de texte en dur dans les composants) mais ne pas investir dans les traductions.
 
 ---
 
 ### OD-11 : Monetisation et impact sur l'UX
 
+**Statut** : Reporte -- 2026-04-03
+
 **Question** : Le modele freemium (prevu en phase 3 du PRD) impactera l'experience. Quelles fonctionnalites sont candidates au paywall ?
 
-**Recommandation** : A definir post-MVP. Ne pas designer de fonctionnalites avec un paywall en tete pour le Lot 0. Le risque est de degrader l'experience gratuite au point de perdre l'adoption.
+**Decision** : Reporter monetisation.
+
+**Justification** : Gratuit en Lot 0, monetisation post-MVP. Ne pas designer de fonctionnalites avec un paywall en tete pour le Lot 0. Le risque est de degrader l'experience gratuite au point de perdre l'adoption.
 
 ---
 
-## Resume par priorite
+## Resume
 
-| ID | Decision | Priorite | Bloquant pour |
-|----|----------|----------|---------------|
-| OD-01 | App unique vs separee (parent) | Haute | Architecture routes |
-| OD-02 | Auto-eval vs scoring auto MCQ | Haute | Composant session |
-| OD-03 | Position bouton "Ajouter des pages" | Haute | Navigation capture |
-| OD-04 | Moment saisie emploi du temps | Moyenne | Flow creation chapitre |
-| OD-05 | Regressions dans le debrief | Moyenne | Composant debrief |
-| OD-06 | Notifications parent par defaut | Moyenne | Preferences parent |
-| OD-07 | Demo archive vs supprime | Moyenne | Logique archivage |
-| OD-08 | Multi-enfants parent | Basse | Post-MVP |
-| OD-09 | Partage entre eleves | Basse | Post-MVP |
-| OD-10 | Internationalisation | Basse | Post-MVP |
-| OD-11 | Monetisation et paywall | Basse | Phase 3 |
+| ID | Decision | Statut | Date | Justification |
+|----|----------|--------|------|---------------|
+| OD-01 | App unique, profil parent avec switch | Decide | 2026-04-03 | Simplifie le developpement, une seule codebase |
+| OD-02 | Scoring automatique sur tout via LLM | Decide | 2026-04-03 | Plus fiable que l'auto-evaluation |
+| OD-03 | Deux boutons "Ajouter des pages" | Decide | 2026-04-03 | Accessibilite maximale, deux contextes naturels |
+| OD-04 | Reporter emploi du temps | Reporte | 2026-04-03 | PRD S11 est post-MVP |
+| OD-05 | Ton neutre pour regressions | Decide | 2026-04-03 | Growth mindset |
+| OD-06 | 1 notification parent/semaine | Decide | 2026-04-04 | Pas de spam en Lot 0 |
+| OD-07 | Demo visible, marquee, suppressible | Decide | 2026-04-03 | Reference pour l'eleve |
+| OD-08 | Reporter multi-enfants | Reporte | 2026-04-03 | Lot 0 = 1 pere + 1 fils |
+| OD-09 | Reporter partage entre eleves | Reporte | 2026-04-03 | Hors scope Lot 0 et MVP |
+| OD-10 | Reporter localisation | Reporte | 2026-04-03 | MVP = marche francais |
+| OD-11 | Reporter monetisation | Reporte | 2026-04-03 | Gratuit en Lot 0 |


### PR DESCRIPTION
## Summary

- **README.md** : refonte complete avec badge CI, description projet, stack technique, quick start, diagramme Mermaid (architecture hexagonale + 4 bounded contexts), etat du projet (326 tests, 44.7% coverage), lien design system, commandes utiles, licence MIT
- **docs/ux/open-decisions.md** : 11 decisions UX documentees avec statut (Decide/Reporte), date et justification -- OD-01 a OD-11

## Test plan

- [ ] Verifier le rendu Markdown du README sur GitHub (badge CI, diagramme Mermaid)
- [ ] Verifier que les liens internes (docs/, design system) fonctionnent
- [ ] Verifier le tableau resume des OD dans open-decisions.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)