### PR TITLE
feat: ajouter testIDs sur composants mobile interactifs

### DIFF
--- a/mobile/app/(tabs)/capture.tsx
+++ b/mobile/app/(tabs)/capture.tsx
@@ -54,6 +54,7 @@ export default function CaptureScreen() {
           Cadre ton cahier{'\n'}dans le rectangle
         </RNText>
         <Button
+          testID="capture-photo-btn"
           title="📸  Prendre une photo"
           variant="primary"
           onPress={handleCapture}
@@ -89,6 +90,7 @@ export default function CaptureScreen() {
       {/* Actions */}
       <RNView style={[styles.actions, { paddingBottom: insets.bottom + spacing.md }]}>
         <Button
+          testID="capture-gallery-btn"
           title="🖼  Galerie"
           variant="outline"
           onPress={() => {/* TODO: image picker */}}

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -138,6 +138,7 @@ export default function DashboardScreen() {
       {/* Capture CTA */}
       <RNView style={[styles.section, { alignItems: 'center' }]}>
         <Button
+          testID="dashboard-capture-btn"
           title="📸  Capturer un cours"
           variant="primary"
           fullWidth
@@ -156,7 +157,7 @@ function ChapterCard({ chapter }: { chapter: Chapter }) {
   const pct = total > 0 ? Math.round((mastered / total) * 100) : 0;
 
   return (
-    <Pressable onPress={() => router.push(`/chapter/${chapter.id}`)}>
+    <Pressable testID="dashboard-chapter-card" onPress={() => router.push(`/chapter/${chapter.id}`)}>
       <Card style={{ marginBottom: spacing.sm }}>
         <RNView style={styles.chapterHeader}>
           <RNView style={{ flex: 1 }}>
@@ -177,6 +178,7 @@ function ChapterCard({ chapter }: { chapter: Chapter }) {
             {chapter.item_count} items
           </RNText>
           <Button
+            testID="dashboard-revise-btn"
             title={chapter.is_demo ? 'Essayer' : 'Réviser'}
             variant="secondary"
             onPress={() => router.push(`/chapter/${chapter.id}`)}

--- a/mobile/app/chapter/[id].tsx
+++ b/mobile/app/chapter/[id].tsx
@@ -155,7 +155,7 @@ export default function ChapterScreen() {
                 </Pressable>
 
                 {isExpanded && (
-                  <RNView style={styles.itemList}>
+                  <RNView testID="chapter-item-list" style={styles.itemList}>
                     {notion.items.map((item) => (
                       <RNView key={item.id} style={styles.itemRow}>
                         <RNView style={{ flex: 1 }}>
@@ -191,6 +191,7 @@ export default function ChapterScreen() {
       {/* Floating CTA */}
       <RNView style={[styles.floatingCTA, { backgroundColor: colors.background, borderTopColor: colors.border, paddingBottom: insets.bottom + spacing.sm }]}>
         <Button
+          testID="chapter-revise-btn"
           title="🎯  Lancer une session"
           variant="primary"
           fullWidth

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -54,6 +54,7 @@ export default function OnboardingScreen() {
           colors={colors}
         />
         <Button
+          testID="onboarding-start-btn"
           title="📸  Capturer"
           variant="primary"
           fullWidth
@@ -84,6 +85,7 @@ export default function OnboardingScreen() {
             8 questions prêtes · 3 min
           </RNText>
           <Button
+            testID="onboarding-seed-btn"
             title={seeding ? 'Chargement...' : 'Essayer →'}
             variant="secondary"
             onPress={handleSeedDemo}

--- a/mobile/app/processing.tsx
+++ b/mobile/app/processing.tsx
@@ -66,7 +66,7 @@ export default function ProcessingScreen() {
           {PHASE_MESSAGES[phase]}
         </RNText>
 
-        <RNView style={{ width: '80%', marginTop: spacing.xl }}>
+        <RNView testID="processing-indicator" style={{ width: '80%', marginTop: spacing.xl }}>
           <ProgressBar progress={progress} height={10} />
           <RNText style={[typography.caption, { color: colors.textSecondary, textAlign: 'center', marginTop: spacing.sm }]}>
             Phase {phase}/3 · {Math.round(progress * 100)}%

--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -199,7 +199,7 @@ export default function SessionScreen() {
         <RNView style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
           {/* Header */}
           <RNView style={styles.sessionHeader}>
-            <Pressable onPress={() => router.back()}>
+            <Pressable testID="session-quit-btn" onPress={() => router.back()}>
               <RNText style={[typography.body, { color: colors.tint }]}>← Quitter</RNText>
             </Pressable>
             <RNText style={[typography.captionBold, { color: colors.text }]}>Session</RNText>
@@ -280,7 +280,7 @@ export default function SessionScreen() {
       <RNView style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
         {/* Header */}
         <RNView style={styles.sessionHeader}>
-          <Pressable onPress={() => router.back()}>
+          <Pressable testID="session-quit-btn" onPress={() => router.back()}>
             <RNText style={[typography.body, { color: colors.tint }]}>← Quitter</RNText>
           </Pressable>
           <RNText style={[typography.captionBold, { color: colors.text }]}>Session</RNText>
@@ -289,12 +289,12 @@ export default function SessionScreen() {
           </RNText>
         </RNView>
         <RNView style={{ paddingHorizontal: spacing.md }}>
-          <ProgressBar progress={(currentIdx + 1) / total} height={4} />
+          <ProgressBar testID="session-progress-bar" progress={(currentIdx + 1) / total} height={4} />
         </RNView>
 
         {/* Question content */}
         <ScrollView style={styles.content} contentContainerStyle={{ paddingBottom: spacing.xxl }}>
-          <RNText style={[typography.h3, { color: colors.text, marginTop: spacing.lg }]}>
+          <RNText testID="session-question-text" style={[typography.h3, { color: colors.text, marginTop: spacing.lg }]}>
             {question.rendered_prompt}
           </RNText>
 
@@ -328,6 +328,7 @@ export default function SessionScreen() {
               </RNView>
             ) : (
               <TextInput
+                testID="session-answer-input"
                 style={[
                   styles.textInput,
                   {
@@ -350,6 +351,7 @@ export default function SessionScreen() {
         {/* Bottom actions */}
         <RNView style={[styles.bottomActions, { borderTopColor: colors.border, paddingBottom: insets.bottom + spacing.sm }]}>
           <Button
+            testID="session-validate-btn"
             title="Valider"
             variant="primary"
             fullWidth
@@ -541,6 +543,7 @@ function FeedbackView({
       {/* Next button */}
       <RNView style={[styles.bottomActions, { borderTopColor: colors.border, paddingBottom: insets.bottom + spacing.sm }]}>
         <Button
+          testID="session-next-btn"
           title={currentIdx + 1 >= total ? 'Voir le bilan' : 'Suivant →'}
           variant="primary"
           fullWidth

--- a/mobile/components/MasteryBar.tsx
+++ b/mobile/components/MasteryBar.tsx
@@ -40,7 +40,7 @@ export function MasteryBar({ breakdown, height = 10, showLabel = true }: Props) 
   ].filter((s) => s.value > 0);
 
   return (
-    <RNView style={{ gap: spacing.xs }}>
+    <RNView testID="mastery-bar" style={{ gap: spacing.xs }}>
       <RNView
         style={{
           height,

--- a/mobile/components/Themed.tsx
+++ b/mobile/components/Themed.tsx
@@ -153,15 +153,18 @@ export function ProgressBar({
   progress,
   color,
   height = 8,
+  testID,
 }: {
   progress: number;
   color?: string;
   height?: number;
+  testID?: string;
 }) {
   const colors = useColors();
   const clamp = Math.max(0, Math.min(1, progress));
   return (
     <DefaultView
+      testID={testID}
       style={{
         height,
         borderRadius: height / 2,


### PR DESCRIPTION
## Summary

- Ajoute des `testID` sur tous les composants mobiles interactifs pour permettre les tests E2E Maestro (issue #47)
- Convention respectee : `testID="ecran-element-action"` (ex: `session-validate-btn`, `dashboard-chapter-card`)
- Ajoute le support `testID` sur le composant `ProgressBar` qui ne l'acceptait pas

### testIDs ajoutes

| Ecran | testID |
|-------|--------|
| Dashboard | `dashboard-chapter-card`, `dashboard-revise-btn`, `dashboard-capture-btn` |
| Capture | `capture-photo-btn`, `capture-gallery-btn` |
| Session | `session-answer-input`, `session-validate-btn`, `session-next-btn`, `session-quit-btn`, `session-question-text`, `session-progress-bar` |
| Onboarding | `onboarding-start-btn`, `onboarding-seed-btn` |
| Chapter | `chapter-revise-btn`, `chapter-item-list` |
| Processing | `processing-indicator` |
| MasteryBar | `mastery-bar` |

## Test plan

- [x] `cd mobile && npx jest --verbose` : 106 tests passent sans regression
- [ ] Verifier que les testIDs sont accessibles via Maestro (`assertVisible id="session-validate-btn"`)

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)