### PR TITLE
infra: Dockerfile multi-stage backend (fixes #55)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,25 @@
+# Build artifacts
+bin/
+*.exe
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Test artifacts
+coverage.out
+*.test
+
+# Environment files (secrets)
+.env
+.env.*
+
+# Git
+.git
+.gitignore
+
+# Documentation
+*.md
+LICENSE

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,49 @@
+# ============================================================================
+# Stage 1: Build
+# ============================================================================
+FROM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.Version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" \
+    -o /server ./cmd/server
+
+# ============================================================================
+# Stage 2: Runtime
+# ============================================================================
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY --from=builder /server /server
+COPY migrations/ /migrations/
+
+EXPOSE 8080
+
+# ── Environment variables ────────────────────────────────────────────────────
+# DATABASE_URL        — PostgreSQL connection string (required)
+# PORT                — HTTP listen port (default: 8080)
+# GIN_MODE            — Gin framework mode: debug | release | test
+# MIGRATIONS_DIR      — Path to SQL migration files inside the container
+# REDIS_URL           — Redis connection string (optional)
+# S3_ENDPOINT         — S3-compatible endpoint for object storage (optional)
+# S3_BUCKET           — S3 bucket name (optional)
+# S3_ACCESS_KEY       — S3 access key (optional)
+# S3_SECRET_KEY       — S3 secret key (optional)
+# ANTHROPIC_API_KEY   — Anthropic API key for LLM features (optional)
+# OCR_PROVIDER        — OCR provider: gemini | google-vision (optional)
+ENV GIN_MODE=release
+ENV MIGRATIONS_DIR=/migrations
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -qO- http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["/server"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: help deps build run dev test test-unit test-integration \
         lint fmt vet db-migrate db-create-migration swagger clean \
-        bench bench-idp bench-ocr bench-all bench-report
+        docker-build bench bench-idp bench-ocr bench-all bench-report
 
 .DEFAULT_GOAL := help
 
@@ -233,6 +233,13 @@ bench-report: ## Génère le rapport HTML depuis les derniers résultats
 	@echo "$(CYAN)Génération du rapport HTML...$(RESET)"
 	@$(GO) run $(BENCH_CMD) --report $(if $(RUN),--report-run=$(RUN)) $(if $(REPORT_OUTPUT),--report-output=$(REPORT_OUTPUT))
 	@echo "$(GREEN)Rapport généré.$(RESET)"
+
+# ------------------------------------------------------------
+# Docker
+# ------------------------------------------------------------
+
+docker-build: ## Build l'image Docker du backend
+	docker build -t revisemieux-backend .
 
 # ------------------------------------------------------------
 # Clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,19 @@ services:
     profiles:
       - storage
 
+  # -----------------------------------------------------------
+  # Backend API (uncomment for containerised backend)
+  # -----------------------------------------------------------
+  # backend:
+  #   build: ./backend
+  #   ports: ['8080:8080']
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #     redis:
+  #       condition: service_healthy
+  #   env_file: .env
+
 volumes:
   pg_data:
   redis_data:


### PR DESCRIPTION
## Summary

- Creates `backend/Dockerfile` with a multi-stage build: Go 1.25 Alpine builder + Alpine 3.20 runtime
- `CGO_ENABLED=0` produces a static binary (~31 MB), version injected via `git describe`
- Runtime image: Alpine 3.20 + ca-certificates + tzdata only (~42 MB total)
- Migrations copied at `/migrations`, `MIGRATIONS_DIR` env set by default
- Non-root-safe (no privileged ports), `GIN_MODE=release`, `ENTRYPOINT ["/server"]`
- Health check on `/health` (30s interval, 5s timeout, 3 retries)
- Adds `backend/.dockerignore` to reduce build context
- Adds `docker-build` target to `backend/Makefile`
- Adds commented backend service to `docker-compose.yml` for prod reference

## Image size

| Component | Size |
|-----------|------|
| Go binary | 31 MB |
| Alpine 3.20 base | ~8 MB |
| ca-certificates + tzdata | ~3 MB |
| Migrations | 28 KB |
| **Total** | **~42 MB** |

> Note: the 30 MB target assumes a minimal binary. At 31 MB the binary alone exceeds it due to Gin, Swagger, pgx, and multiple LLM client deps. The image is already stripped (`-s -w` ldflags) with no debug symbols.

## Test plan

- [x] `docker build -t revisemieux-backend ./backend` succeeds
- [x] Binary starts (panics on missing JWT_SECRET as expected without env)
- [x] Health check configured on `/health`
- [x] Migrations present at `/migrations`
- [ ] `docker compose up` with backend service uncommented starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)