### PR TITLE
feat: monitoring LLM complet (migration + port + adaptateur)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -69,6 +69,11 @@ func main() {
 	idGen := event.UUIDv7Generator{}
 	publisher := eventbus.NewLogPublisher()
 
+	// --- LLM Call Logger ---
+	llmLogger := postgres.NewLLMCallLogger(pool)
+	_ = llmLogger // TODO: pass to LLM clients for instrumentation
+	log.Println("LLM call logger initialized")
+
 	// --- Repositories ---
 	chapterRepo := postgres.NewChapterRepository(pool)
 	masteryRepo := postgres.NewMasteryRepository(pool)

--- a/backend/internal/domain/event/llm_logger.go
+++ b/backend/internal/domain/event/llm_logger.go
@@ -1,0 +1,34 @@
+package event
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LLMCallEntry represents a single LLM API call for logging and monitoring.
+type LLMCallEntry struct {
+	Timestamp     time.Time
+	CallType      string // "structuration", "fidelity", "question_gen", "ocr", "scoring"
+	Model         string
+	PromptVersion string
+	PromptHash    string
+	TokensInput   int
+	TokensOutput  int
+	DurationMs    int64
+	CostUSD       float64
+	Status        string // "success", "error", "timeout"
+	ItemsCount    *int
+	AvgConfidence *float64
+	CacheHit      bool
+	Batch         bool
+	UserID        *uuid.UUID
+	ChapterID     *uuid.UUID
+	Error         string
+}
+
+// LLMCallLogger defines the port for logging LLM API calls.
+type LLMCallLogger interface {
+	LogCall(ctx context.Context, entry LLMCallEntry) error
+}

--- a/backend/internal/domain/event/llm_logger_test.go
+++ b/backend/internal/domain/event/llm_logger_test.go
@@ -1,0 +1,92 @@
+package event
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestLLMCallEntry_AllFields(t *testing.T) {
+	userID := uuid.New()
+	chapterID := uuid.New()
+	itemsCount := 5
+	avgConfidence := 0.92
+
+	entry := LLMCallEntry{
+		Timestamp:     time.Now(),
+		CallType:      "structuration",
+		Model:         "claude-sonnet-4-20250514",
+		PromptVersion: "v1.0",
+		PromptHash:    "abc123",
+		TokensInput:   1500,
+		TokensOutput:  800,
+		DurationMs:    2345,
+		CostUSD:       0.0042,
+		Status:        "success",
+		ItemsCount:    &itemsCount,
+		AvgConfidence: &avgConfidence,
+		CacheHit:      false,
+		Batch:         false,
+		UserID:        &userID,
+		ChapterID:     &chapterID,
+		Error:         "",
+	}
+
+	if entry.CallType != "structuration" {
+		t.Errorf("CallType = %q, want %q", entry.CallType, "structuration")
+	}
+	if entry.TokensInput != 1500 {
+		t.Errorf("TokensInput = %d, want %d", entry.TokensInput, 1500)
+	}
+	if entry.TokensOutput != 800 {
+		t.Errorf("TokensOutput = %d, want %d", entry.TokensOutput, 800)
+	}
+	if *entry.ItemsCount != 5 {
+		t.Errorf("ItemsCount = %d, want %d", *entry.ItemsCount, 5)
+	}
+	if *entry.AvgConfidence != 0.92 {
+		t.Errorf("AvgConfidence = %f, want %f", *entry.AvgConfidence, 0.92)
+	}
+	if *entry.UserID != userID {
+		t.Errorf("UserID mismatch")
+	}
+	if *entry.ChapterID != chapterID {
+		t.Errorf("ChapterID mismatch")
+	}
+}
+
+func TestLLMCallEntry_DefaultValues(t *testing.T) {
+	entry := LLMCallEntry{}
+
+	if entry.TokensInput != 0 {
+		t.Errorf("default TokensInput = %d, want 0", entry.TokensInput)
+	}
+	if entry.TokensOutput != 0 {
+		t.Errorf("default TokensOutput = %d, want 0", entry.TokensOutput)
+	}
+	if entry.DurationMs != 0 {
+		t.Errorf("default DurationMs = %d, want 0", entry.DurationMs)
+	}
+	if entry.CostUSD != 0 {
+		t.Errorf("default CostUSD = %f, want 0", entry.CostUSD)
+	}
+	if entry.CacheHit != false {
+		t.Errorf("default CacheHit = %v, want false", entry.CacheHit)
+	}
+	if entry.Batch != false {
+		t.Errorf("default Batch = %v, want false", entry.Batch)
+	}
+	if entry.ItemsCount != nil {
+		t.Errorf("default ItemsCount = %v, want nil", entry.ItemsCount)
+	}
+	if entry.AvgConfidence != nil {
+		t.Errorf("default AvgConfidence = %v, want nil", entry.AvgConfidence)
+	}
+	if entry.UserID != nil {
+		t.Errorf("default UserID = %v, want nil", entry.UserID)
+	}
+	if entry.ChapterID != nil {
+		t.Errorf("default ChapterID = %v, want nil", entry.ChapterID)
+	}
+}

--- a/backend/internal/infra/postgres/llm_logger.go
+++ b/backend/internal/infra/postgres/llm_logger.go
@@ -1,0 +1,40 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/popul/revisemieux/internal/domain/event"
+)
+
+// Compile-time check that LLMCallLogger implements event.LLMCallLogger.
+var _ event.LLMCallLogger = (*LLMCallLogger)(nil)
+
+// LLMCallLogger implements event.LLMCallLogger using PostgreSQL.
+type LLMCallLogger struct {
+	pool *pgxpool.Pool
+}
+
+// NewLLMCallLogger creates a new LLMCallLogger.
+func NewLLMCallLogger(pool *pgxpool.Pool) *LLMCallLogger {
+	return &LLMCallLogger{pool: pool}
+}
+
+// LogCall inserts an LLM call log entry into the database.
+func (l *LLMCallLogger) LogCall(ctx context.Context, entry event.LLMCallEntry) error {
+	_, err := l.pool.Exec(ctx, `
+		INSERT INTO llm_call_logs
+		(timestamp, call_type, model, prompt_version, prompt_hash,
+		 tokens_input, tokens_output, duration_ms, cost_usd, status,
+		 items_count, avg_confidence, cache_hit, batch, user_id, chapter_id, error)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+		entry.Timestamp, entry.CallType, entry.Model, entry.PromptVersion, entry.PromptHash,
+		entry.TokensInput, entry.TokensOutput, entry.DurationMs, entry.CostUSD, entry.Status,
+		entry.ItemsCount, entry.AvgConfidence, entry.CacheHit, entry.Batch,
+		entry.UserID, entry.ChapterID, entry.Error)
+	if err != nil {
+		return fmt.Errorf("llm_logger.LogCall: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/infra/postgres/llm_logger_test.go
+++ b/backend/internal/infra/postgres/llm_logger_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/popul/revisemieux/internal/domain/event"
+	"github.com/popul/revisemieux/internal/infra/postgres"
+)
+
+func TestLLMCallLogger_LogCall(t *testing.T) {
+	tdb := setupTestDB(t)
+	logger := postgres.NewLLMCallLogger(tdb.pool)
+
+	itemsCount := 10
+	avgConfidence := 0.95
+	userID := uuid.Must(uuid.NewV7())
+	chapterID := uuid.Must(uuid.NewV7())
+
+	entry := event.LLMCallEntry{
+		Timestamp:     time.Now().UTC().Truncate(time.Microsecond),
+		CallType:      "structuration",
+		Model:         "claude-sonnet-4-20250514",
+		PromptVersion: "v1.0",
+		PromptHash:    "sha256-abc123",
+		TokensInput:   1500,
+		TokensOutput:  800,
+		DurationMs:    2345,
+		CostUSD:       0.0042,
+		Status:        "success",
+		ItemsCount:    &itemsCount,
+		AvgConfidence: &avgConfidence,
+		CacheHit:      false,
+		Batch:         false,
+		UserID:        &userID,
+		ChapterID:     &chapterID,
+		Error:         "",
+	}
+
+	err := logger.LogCall(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("LogCall() error = %v", err)
+	}
+
+	// Verify the entry was inserted
+	var count int
+	err = tdb.pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM llm_call_logs WHERE call_type = 'structuration'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query error = %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestLLMCallLogger_LogCall_NilOptionalFields(t *testing.T) {
+	tdb := setupTestDB(t)
+	logger := postgres.NewLLMCallLogger(tdb.pool)
+
+	entry := event.LLMCallEntry{
+		Timestamp:     time.Now().UTC().Truncate(time.Microsecond),
+		CallType:      "ocr",
+		Model:         "gpt-4o",
+		PromptVersion: "v2.1",
+		PromptHash:    "sha256-def456",
+		TokensInput:   500,
+		TokensOutput:  200,
+		DurationMs:    1200,
+		CostUSD:       0.001,
+		Status:        "error",
+		ItemsCount:    nil,
+		AvgConfidence: nil,
+		CacheHit:      false,
+		Batch:         false,
+		UserID:        nil,
+		ChapterID:     nil,
+		Error:         "timeout after 30s",
+	}
+
+	err := logger.LogCall(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("LogCall() with nil optional fields error = %v", err)
+	}
+
+	// Verify NULL optional fields
+	var hasItemsCount, hasAvgConfidence, hasUserID, hasChapterID bool
+	err = tdb.pool.QueryRow(context.Background(), `
+		SELECT items_count IS NOT NULL, avg_confidence IS NOT NULL,
+		       user_id IS NOT NULL, chapter_id IS NOT NULL
+		FROM llm_call_logs WHERE call_type = 'ocr'
+	`).Scan(&hasItemsCount, &hasAvgConfidence, &hasUserID, &hasChapterID)
+	if err != nil {
+		t.Fatalf("query error = %v", err)
+	}
+	if hasItemsCount {
+		t.Error("expected items_count to be NULL")
+	}
+	if hasAvgConfidence {
+		t.Error("expected avg_confidence to be NULL")
+	}
+	if hasUserID {
+		t.Error("expected user_id to be NULL")
+	}
+	if hasChapterID {
+		t.Error("expected chapter_id to be NULL")
+	}
+}

--- a/backend/internal/infra/postgres/testhelper_test.go
+++ b/backend/internal/infra/postgres/testhelper_test.go
@@ -67,7 +67,7 @@ var runtimeCaller = runtime.Caller
 // Only root tables need to be listed — CASCADE handles FK-dependent tables.
 func (tdb *testDB) truncateAll() {
 	ctx := context.Background()
-	_, _ = tdb.pool.Exec(ctx, `TRUNCATE users, exams, templates CASCADE`)
+	_, _ = tdb.pool.Exec(ctx, `TRUNCATE users, exams, templates, llm_call_logs CASCADE`)
 }
 
 // seedUser inserts a test user and returns its ID.

--- a/backend/migrations/004_llm_call_logs.sql
+++ b/backend/migrations/004_llm_call_logs.sql
@@ -1,0 +1,26 @@
+-- Migration: 004_llm_call_logs.sql
+-- Table de monitoring des appels LLM pour suivi coûts, latence et qualité.
+
+CREATE TABLE llm_call_logs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    call_type       TEXT NOT NULL,  -- 'structuration', 'fidelity', 'question_gen', 'coherence', 'ocr', 'scoring'
+    model           TEXT NOT NULL,
+    prompt_version  TEXT NOT NULL,
+    prompt_hash     TEXT NOT NULL,
+    tokens_input    INTEGER NOT NULL DEFAULT 0,
+    tokens_output   INTEGER NOT NULL DEFAULT 0,
+    duration_ms     INTEGER NOT NULL DEFAULT 0,
+    cost_usd        DOUBLE PRECISION NOT NULL DEFAULT 0,
+    status          TEXT NOT NULL DEFAULT 'success',  -- 'success', 'error', 'timeout'
+    items_count     INTEGER,
+    avg_confidence  DOUBLE PRECISION,
+    cache_hit       BOOLEAN NOT NULL DEFAULT false,
+    batch           BOOLEAN NOT NULL DEFAULT false,
+    user_id         UUID,
+    chapter_id      UUID,
+    error           TEXT
+);
+
+CREATE INDEX idx_llm_call_logs_type_ts ON llm_call_logs (call_type, timestamp);
+CREATE INDEX idx_llm_call_logs_model_ts ON llm_call_logs (model, timestamp);


### PR DESCRIPTION
## Summary
- Add `llm_call_logs` SQL migration (004) with indexes on call_type+timestamp and model+timestamp
- Add `LLMCallLogger` port interface in `domain/event/` with `LLMCallEntry` struct (zero external dependencies)
- Add postgres adapter `LLMCallLogger` in `infra/postgres/` implementing the port via pgx
- Wire the logger in `main.go` (created but not yet injected into LLM clients -- instrumentation is a separate step)
- Unit tests for domain entry struct + integration tests for the postgres adapter

Fixes #44

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all 386+ existing tests + 2 new domain tests)
- [ ] Integration tests pass with a live DB (`go test -tags=integration ./internal/infra/postgres/...`)
- [ ] Migration applies cleanly on a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)