### PR TITLE
docs: introduce Lot -1 in PRD, ACs, MVP-scope, tracker

### DIFF
--- a/docs/MVP-scope.md
+++ b/docs/MVP-scope.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Total ACs** | 171 (8 zones) · dont **53 Lot 0** (33 P1 + 20 P2) |
+| **Total ACs** | 186 (9 zones) · 15 Lot -1 (Z0) + 53 Lot 0 (Z1-Z8 ⊂) + 118 différés au MVP |
 
 ---
 
@@ -19,6 +19,37 @@
 | **P1** | La boucle fonctionne. Version locale minimale père-fils. |
 | **P2** | Expérience quotidienne complète sur les 4 packs pilotes. |
 | **—** | Différé au MVP complet. |
+
+| Lot -1 | Description |
+|---|---|
+| **bloquant** | AC nécessaire à la livraison du site one-shot web-v0. La livraison Lot -1 est atomique : pas de répartition P1/P2. |
+| **—** | N'appartient pas au Lot -1 (s'applique au Lot 0+ uniquement). |
+
+> Z0 (Lot -1) est totalement disjoint de Z1-Z8. Voir [`ac/Z0.md`](ac/Z0.md) pour le détail des 15 ACs.
+
+---
+
+## Z0 — Lot -1 (web-v0 one-shot generator) (15 ACs)
+
+| AC | Titre | Lot -1 | Zone aval (Lot 0+) |
+|---|---|---|---|
+| Z0-AC01 | Pipeline end-to-end photos → HTML téléchargeable | bloquant | — |
+| Z0-AC02 | Fiche conforme aux critères de contenu de la skill | bloquant | — |
+| Z0-AC03 | Annexes obligatoires pour la cible 18-20 | bloquant | — |
+| Z0-AC04 | Drawer hamburger fonctionnel | bloquant | — |
+| Z0-AC05 | Deux boutons d'impression distincts | bloquant | — |
+| Z0-AC06 | Mode impression élève masque les corrigés | bloquant | — |
+| Z0-AC07 | Mobile-first et safe area iOS | bloquant | — |
+| Z0-AC08 | SLA de génération | bloquant | — |
+| Z0-AC09 | Survie au timeout de bordure Cloudflare | bloquant | — |
+| Z0-AC10 | Observabilité : logs structurés par job | bloquant | — |
+| Z0-AC11 | Validation Pydantic du résultat LLM (Stage 2) | bloquant Stage 2 | — |
+| Z0-AC12 | Endpoint /preview de validation chrome sans LLM | bloquant | — |
+| Z0-AC13 | Privacy : pas de persistance des photos | bloquant | — |
+| Z0-AC14 | Pas d'authentification mais protection minimale | bloquant | — |
+| Z0-AC15 | Déploiement par image OCI publique | bloquant | — |
+
+> **Note :** les 15 ACs ci-dessus s'appuient sur les critères techniques `[AC-CONT-*]`, `[AC-HTML-*]`, `[AC-15-*]`, `[AC-20-*]` portés par le prompt système (`prompts/study-guide/system.md`). Ces derniers sont la **vérité opérationnelle** vérifiée par le LLM au runtime ; les Z0-AC sont leur **encadrement produit** vérifié par tests d'intégration. Cf. [`ac/Z0.md`](ac/Z0.md).
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -39,6 +39,14 @@
 
 Révise Mieux est un SaaS qui transforme des photos de cahier (manuscrit, schémas, documents) en un assistant de révision personnalisé pour collégiens. À partir d'un upload de cours, le produit génère une carte de leçon structurée, des entraînements adaptatifs (rappel actif, analyse documentaire, méthodes de calcul), des contrôles blancs, et met les parents dans la boucle via un reporting rassurant basé sur des preuves de maîtrise réelles.
 
+Le produit est livré en **trois paliers** :
+
+| Palier | Statut | Périmètre | ACs |
+|---|---|---|---|
+| **Lot -1** (web-v0) | en ligne | Site web one-page : photos → fiche de révision HTML autonome. Pas de comptes, pas de DB, pas de suivi. Cf. § 3.4. | 15 (Z0) |
+| **Lot 0** (pré-MVP père-fils) | en cours | Boucle pédagogique locale, 4 packs pilotes, mastery + spaced rep. Cf. § 3.2. | 53 sur 171 |
+| **MVP** (produit complet) | spec | Multi-utilisateur, ENT, parents actifs, admin. Cf. § 3.1. | 171 |
+
 ### Chapitres pilotes MVP
 
 | Matière | Chapitres pilotes | Pack |
@@ -84,6 +92,38 @@ Révise Mieux est un SaaS qui transforme des photos de cahier (manuscrit, schém
 ---
 
 ## 3. Périmètre & séquencement
+
+### 3.0 Vue d'ensemble du séquencement
+
+Le produit progresse en **trois paliers** complémentaires, chaque palier livrant une valeur autonome :
+
+```
+   Lot -1               Lot 0                    MVP
+  (web-v0)         (pré-MVP local)          (produit complet)
+     │                   │                        │
+     ▼                   ▼                        ▼
+ site one-page     boucle pédagogique       multi-utilisateur
+ photos → HTML  →  père-fils, 4 packs   →   ENT, parents actifs
+ pas de suivi     mastery + spaced rep      admin, RGPD J+30
+     │                   │                        │
+   15 ACs              53 ACs                  171 ACs
+   (Z0)               (Z1-Z8 ⊂)              (Z1-Z8 complet)
+     │                   │                        │
+   en ligne           en cours                  spec
+```
+
+| | Lot -1 | Lot 0 | MVP |
+|---|---|---|---|
+| **Cible utilisateur** | Louis seul, à la dernière minute | binôme père-fils | familles, écoles |
+| **Persistance** | aucune (mémoire process) | local (Postgres) | cloud + S3 + Redis |
+| **Comptes** | aucun | 1 famille | multi-utilisateur |
+| **Suivi** | aucun | mastery + spaced rep | mastery + reporting parent |
+| **Stack** | FastAPI + Jinja + LM Studio | Go + RN + Postgres | Go + RN + Postgres + S3 + Redis |
+| **Déploiement** | image Docker GHCR + K3s homelab | local docker-compose | cloud (à choisir) |
+| **Domaine** | `revise-lab.musso.io` | localhost | TBD |
+| **Détail** | § 3.4 | § 3.2 | § 3.1 |
+
+> **Lot -1 est volontairement disjoint** des autres paliers : il n'est pas un sous-ensemble fonctionnel mais un **produit séparé** qui valide la qualité de la fiche générée. Aucune ligne de code n'est partagée avec Lot 0/MVP en dehors du **prompt système de la skill `study-guide`** (`prompts/study-guide/system.md`), qui est la source unique pour les deux familles de produits.
 
 ### 3.1 Périmètre MVP (produit complet)
 
@@ -179,6 +219,76 @@ Créer les artefacts d'ancrage **avant toute fonctionnalité** :
 8. Onboarding complet (Z8-AC01→AC04, AC08)
 
 > **Critère de validation :** le fils utilise l'app quotidiennement pendant 1 semaine sur un vrai chapitre, avec un exam posé.
+
+### 3.4 Lot -1 — One-shot generator (web-v0)
+
+> **Statut :** en ligne sur `https://revise-lab.musso.io/`. **Code :** [`web-v0/`](../web-v0/). **ACs :** [Z0](ac/Z0.md) (15 critères, tous bloquants).
+>
+> Précède Lot 0. C'est un produit **autonome** qui sert deux objectifs : (1) livrer une valeur immédiate à un seul utilisateur (Louis) sans attendre la boucle pédagogique complète ; (2) valider la qualité opérationnelle de la skill `study-guide` (le prompt système qui fabrique la fiche) sur des données réelles, avant que le pipeline LLM soit ré-implémenté en Go côté Lot 0/MVP.
+
+#### Périmètre
+
+| ✅ Inclus | ❌ Exclu (différé Lot 0) |
+|---|---|
+| Upload multi-photos via formulaire web (1-30 photos, jpg/png/heic/webp). | Comptes utilisateurs / authentification. |
+| Génération d'une **fiche HTML autonome unique** (auto-suffisante, lisible hors ligne). | Persistance des photos ou des fiches au-delà du TTL job (1 h). |
+| Choix de la **note visée** (12-14 / 15-17 / 18-20) qui module la profondeur de la fiche. | Suivi de mastery, sessions répétées, spaced repetition. |
+| Sections 1-6 + Section 8 (annexes) + Section 9 (contrôle blanc) selon la cible. | Reporting parent, notifications, emploi du temps. |
+| **Drawer hamburger** + **deux boutons d'impression** (élève / parent) + mode `@media print`. | Stockage S3 ou base de données. |
+| `/preview` pour tests sans LLM. | Multi-tenant, RGPD J+30, admin backoffice. |
+| Image OCI publique (`ghcr.io/popul/revisemieux-web-v0`) déployée en K3s par ArgoCD. | Mobile native (Lot -1 reste 100% web responsive). |
+
+#### Architecture
+
+```
+[Photos] ──POST /jobs──▶ FastAPI ──HTTP──▶ LM Studio (Qwen 3.6 35B-A3B vision)
+   │                       │
+   │                       ▼
+   │                  Pydantic Fiche (schema.py)
+   │                       │
+   │                       ▼
+   └──poll /jobs/{id}──▶ Jinja shell (shell.html.j2) ──▶ HTML autonome
+                          ↑
+                          └── /preview (fixture.json)
+```
+
+- **Stack** : Python 3.12, FastAPI, Pydantic v2, Jinja2, Uvicorn.
+- **LLM** : Qwen 3.6 35B-A3B via LM Studio (compatible OpenAI), tournant sur la machine de dev locale du développeur. Endpoint configurable `LLM_URL`.
+- **Pipeline** : un seul appel LLM en mode thinking activé (`chat_template_kwargs.enable_thinking=true`), avec rappel des critères d'acceptance ([AC-CONT-*], [AC-HTML-*], [AC-15-*], [AC-20-*]) en fin de prompt utilisateur pour saliency.
+- **Source du prompt** : [`prompts/study-guide/system.md`](../prompts/study-guide/) — **partagée** avec la skill Claude Code `/study-guide` (cf. § 3.0).
+
+#### Personas
+
+Reprend le persona « Louis » du § 4 mais dans un usage solo, à la veille du contrôle. Le parent n'utilise pas le Lot -1 directement (sauf pour imprimer la version « Parent » et corriger avec Louis le lendemain).
+
+#### KPIs Lot -1
+
+| KPI | Cible | Mesure |
+|---|---|---|
+| Délai génération E2E (12 photos, cible 18-20) | P95 ≤ 5 min, P50 ≤ 3 min | logs `elapsed=…` Z0-AC10 |
+| Conformité AC pédagogiques | 100% des [AC-CONT-*] et [AC-HTML-*] applicables | audit manuel + `grep` sur HTML |
+| Taux de troncature | 0% (pas de `finish=length`) | logs `output_truncated` Z0-AC10 |
+| Adoption | Louis utilise pour ≥ 1 contrôle / semaine | autodéclaration |
+| Coût | 0 € (LLM local, GHCR public, K3s homelab) | — |
+
+#### Risques & mitigations
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Le LLM tronque la fiche (output > `max_tokens`) | fiche partielle = inutilisable | logs warning `output_truncated`, alerte explicite, `max_tokens=32000` actuel |
+| Le shell HTML diverge des fiches passées (chrome cassé) | drawer/print buttons KO | endpoint `/preview` + smoke test à chaque déploiement (cf. Z0-AC12) |
+| Photos envoyées à un LLM tiers | leak privé | LLM tourne 100% en local sur la machine du dev (pas de cloud) |
+| LM Studio offline | service down | sortie en erreur explicite côté pod, pas de fallback (acceptable pour Lot -1) |
+| Le prompt source diverge entre Lot -1 et la skill Claude Code | régression silencieuse | `make sync-skill-prompt` + CI `skill-prompt-sync` (cf. § 3.0) |
+
+#### Phases d'implémentation Lot -1
+
+Cf. [`lot-minus-1-tracker.md`](lot-minus-1-tracker.md). Quatre phases, dont 0 et 1 sont livrées :
+
+- **Phase 0** — Shell Jinja + schéma Pydantic + endpoint `/preview` ✓
+- **Phase 1** — Pipeline 1-stage HTML (legacy actuel, conservé tant que Stage 2 n'est pas prêt) ✓
+- **Phase 2** — Pipeline 2-stage JSON : LLM → JSON validé → render Jinja (en cours)
+- **Phase 3** — Itération sur les 15 ACs Z0 + ouverture publique (rate-limit Cloudflare Access)
 
 ---
 

--- a/docs/ac/README.md
+++ b/docs/ac/README.md
@@ -4,7 +4,7 @@
 >
 > | | |
 > |---|---|
-> | **Périmètre** | 8 zones critiques · 171 AC en format Given/When/Then |
+> | **Périmètre** | 9 zones critiques · 186 AC en format Given/When/Then (Z0 = Lot -1, Z1-Z8 = Lot 0+) |
 > | **Usage** | Chaque zone est un fichier séparé pour un chargement ciblé en contexte agent |
 
 ---
@@ -13,6 +13,7 @@
 
 | # | Zone | Risque | ACs | Fichier |
 |---|---|---|---|---|
+| Z0 | **Lot -1 (web-v0 one-shot generator)** | Élevé | 15 | [Z0.md](Z0.md) |
 | Z1 | Transitions Mastery | Très élevé | 28 | [Z1.md](Z1.md) |
 | Z2 | Pipeline J0 — Error paths & timeouts | Très élevé | 18 | [Z2.md](Z2.md) |
 | Z3 | Validation HITL — Skip / Ignore / Qualité items | Élevé | 17 | [Z3.md](Z3.md) |
@@ -21,7 +22,9 @@
 | Z6 | Emploi du temps, Notifications, Engagement & Confiance parent | Élevé | 46 | [Z6.md](Z6.md) |
 | Z7 | Routine de soirée & Orchestration | Très élevé | 26 | [Z7.md](Z7.md) |
 | Z8 | Onboarding & First Use Experience | Très élevé | 8 | [Z8.md](Z8.md) |
-| | **Total** | | **171** | |
+| | **Total** | | **186** | |
+
+> **Z0 (Lot -1)** est disjoint de Z1-Z8 : pas de mastery, pas de spaced rep, pas de comptes. Il décrit la qualité d'un site web one-page qui livre une fiche HTML autonome. Il s'appuie sur les critères techniques `[AC-CONT-*]`, `[AC-HTML-*]`, `[AC-15-*]`, `[AC-20-*]` portés par la skill `study-guide` (`prompts/study-guide/system.md`). Toutes les ACs Z0 sont **bloquantes** pour le Lot -1 — pas de répartition P1/P2.
 
 ---
 

--- a/docs/ac/Z0.md
+++ b/docs/ac/Z0.md
@@ -1,0 +1,129 @@
+# Z0 — Lot -1 (web-v0 one-shot generator)
+
+> Photos → fiche HTML autonome · Chrome stable · SLA < 5 min · Pas de DB, pas de comptes
+>
+> Cette zone décrit les critères d'acceptance du **Lot -1** (`web-v0/`) : un site web one-page qui transforme des photos de cahier en fiche de révision HTML téléchargeable, **sans suivi**, **sans persistance**, **sans comptes**. C'est le palier qui précède Lot 0 (boucle pédagogique locale père-fils) et MVP (produit complet 171 ACs). L'usage cible : Louis, la veille du contrôle, depuis son téléphone.
+>
+> **Toutes les ACs de Z0 appartiennent au Lot -1** (pas de répartition P1/P2 — la livraison est atomique : ce site marche ou il ne marche pas).
+>
+> **Cross-référence avec `prompts/study-guide/system.md`** : les critères `[AC-CONT-*]`, `[AC-HTML-*]`, `[AC-15-*]`, `[AC-20-*]` portés par le prompt système de la skill `study-guide` sont la **vérité opérationnelle** (vérifiés par le LLM pendant la génération). Les Z0-AC ci-dessous sont leur **encadrement produit** (vérifiés par tests d'intégration et par observation utilisateur).
+
+### Z0-AC01 — Pipeline end-to-end photos → HTML téléchargeable
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Un visiteur sur `https://revise-lab.musso.io/` qui sélectionne 1 à 30 photos (jpg, png, heic, webp) et soumet le formulaire. |
+| **WHEN** | Le formulaire envoie un `POST /jobs` (multipart) puis poll `GET /jobs/{id}` toutes les 3 s. |
+| **THEN** | À l'issue du job (`status=done`), `GET /jobs/{id}/result` retourne le HTML complet de la fiche avec `Content-Disposition: attachment; filename="fiche-revision.html"`. Le HTML commence par `<!DOCTYPE html>` et finit par `</html>`. |
+
+### Z0-AC02 — Fiche conforme aux critères de contenu de la skill
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une fiche générée pour une cible donnée (12-14, 15-17 ou 18-20). |
+| **WHEN** | On audite la sortie HTML. |
+| **THEN** | Tous les `[AC-CONT-*]` listés dans `prompts/study-guide/system.md` § « Critères d'acceptance » et applicables à la cible détectée sont satisfaits : ≥3 documents inédits Section 3, encadré N-D-S-I-D si HG/SVT/français/PC, encadré pièges si TRAP, ≥3 exercices d'analyse complets si HG/français, S1+S2 = 30 questions, corrigés 3 lignes ✅/🔍/💡 avec label « Astuce mnémonique » sur chacun, tableau mastery présent. |
+
+### Z0-AC03 — Annexes obligatoires pour la cible 18-20
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une fiche générée avec `target` ∈ {18, 19, 20, /20, excellence}. |
+| **WHEN** | On parcourt le HTML. |
+| **THEN** | La Section 8 « Annexes 18-20 » contient les 7 sous-parties (a)→(g) — frise, vocabulaire exhaustif, pièges renforcés, fiches personnages (si applicable), tableau comparatif, rédactions modèles + grille d'évaluation, méthodes par type de document. La Section 9 « Session 3 — Contrôle blanc » contient 10 questions numérotées **Q31→Q40** et une question MINDMAP_REBUILD sous forme de **SVG inline ~500×300 px** (jamais ASCII). Cf. `[AC-20-*]` dans `prompts/study-guide/system.md`. |
+
+### Z0-AC04 — Drawer hamburger fonctionnel
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une fiche HTML servie par le shell. |
+| **WHEN** | L'utilisateur clique sur le bouton hamburger en haut à gauche, puis re-clique (ou clique sur le backdrop, ou appuie sur Échap). |
+| **THEN** | Le drawer latéral coulisse depuis la gauche avec un backdrop semi-transparent. La liste des ancres de sommaire est cliquable et ferme le drawer au clic. Le bouton bascule de `☰` à `✕` quand ouvert. Fonctionnel desktop **et** mobile (Safari iOS, Chrome Android). |
+
+### Z0-AC05 — Deux boutons d'impression distincts
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une fiche HTML servie. |
+| **WHEN** | L'utilisateur clique sur « 🖨️ Élève » ou « 🖨️ Parent ». |
+| **THEN** | Avant l'ouverture de la boîte d'impression, `<body>` reçoit la classe `print-eleve` ou `print-parent`. Après fermeture (`window.afterprint`), les classes sont retirées automatiquement et la fiche redevient navigable normalement. Les deux boutons sont obligatoires : un seul = non conforme. |
+
+### Z0-AC06 — Mode impression élève masque les corrigés
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une fiche HTML, mode élève actif (`<body class="print-eleve">`). |
+| **WHEN** | L'utilisateur déclenche l'impression (`⌘P` / `Ctrl+P`). |
+| **THEN** | La preview montre toutes les questions des Sessions 1, 2 et 3, mais **aucun corrigé** : ni la Section 6A, ni les `<details class="corrige">`, ni les corrigés modèles des exercices d'analyse. Le mode parent imprime tout, `<details>` forcés ouverts. |
+
+### Z0-AC07 — Mobile-first et safe area iOS
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une fiche servie sur iPhone Safari ou Android Chrome. |
+| **WHEN** | L'utilisateur consulte la page en portrait, en landscape, et avec la dynamic island / le notch. |
+| **THEN** | (a) Hamburger et boutons d'impression respectent `env(safe-area-inset-*)`. (b) Sur écrans `< 480px`, les deux boutons d'impression descendent en bas de l'écran (zone pouce) et occupent toute la largeur. (c) Tableaux dans `<div class="table-wrap">` avec `overflow-x:auto`. (d) Mini-cartes en grille 1 colonne en mobile, 2+ en desktop. (e) Aucun `position:fixed` ne masque le contenu sans compensation de padding. Cf. `[AC-HTML-04..07]`. |
+
+### Z0-AC08 — SLA de génération
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Une soumission de 12 photos (~5 Mo total) avec cible 18-20. |
+| **WHEN** | Le job est traité par le LLM Qwen 3.6 35B-A3B (vision + thinking) sur LM Studio local. |
+| **THEN** | P95 du délai `created_at` → `finished_at` ≤ **300 s** (5 min). P50 ≤ 180 s. Si `finish_reason=length` apparaît dans les logs, c'est une régression bloquante : il faut soit augmenter `max_tokens`, soit raccourcir le prompt système. |
+
+### Z0-AC09 — Survie au timeout de bordure Cloudflare
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Le service est exposé via Cloudflare (timeout edge 100 s sur le plan Free). |
+| **WHEN** | Une génération dépasse 100 s. |
+| **THEN** | Le pattern `POST /jobs` retourne immédiatement `{job_id}` (≤ 5 s). Le client poll `GET /jobs/{id}` qui retourne en quelques ms. Aucune requête HTTP unique ne dépasse 100 s. Si l'utilisateur recharge la page pendant la génération, il peut re-coller le `job_id` dans l'URL pour retrouver son résultat tant que le TTL en mémoire (par défaut 1 h) n'est pas dépassé. |
+
+### Z0-AC10 — Observabilité : logs structurés par job
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Un job exécuté en pod K3s (`kubectl logs deploy/revise -n revise`). |
+| **WHEN** | On filtre les logs par `job=<id>`. |
+| **THEN** | On retrouve dans l'ordre : `job=… created images=N raw_bytes=…`, `job=… status=running`, `job=… llm_request model=… max_tokens=… target_band=…`, `job=… llm_response elapsed=…s finish=… prompt_tokens=… completion_tokens=… reasoning_tokens=…`, `job=… html raw_chars=… ends_with_html=…`, et soit `status=done elapsed=…s html_chars=…` soit `status=error` avec traceback. Tout WARNING (`output_truncated`, `html_likely_truncated`) doit être levé explicitement. |
+
+### Z0-AC11 — Validation Pydantic du résultat LLM (Stage 2)
+| | |
+|---|---|
+| **Lot -1** | bloquant à partir du Stage 2 |
+| **GIVEN** | Le pipeline 2-stage (Stage 1 = LLM extraction → JSON ; Stage 2 = Jinja render) est actif. |
+| **WHEN** | Le LLM retourne un JSON. |
+| **THEN** | `Fiche.model_validate(...)` est appelé. En cas d'échec, le job passe en `status=error` avec un message qui liste les chemins JSON et les types attendus. Le HTML rendu n'est jamais servi tant que la validation Pydantic n'est pas passée. |
+
+### Z0-AC12 — Endpoint /preview de validation chrome sans LLM
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Le service tourne. |
+| **WHEN** | Un opérateur ou un test CI fait `GET /preview`. |
+| **THEN** | Le service charge `fixture.json`, le valide via `Fiche.model_validate(...)`, et le passe au shell Jinja. La réponse est un HTML 200 OK qui exerce **toutes les sections** du template (Sections 1→6 + 8 + 9). Aucun appel LLM n'est effectué. Sert de smoke test après chaque déploiement et de support d'itération sur le shell sans coût. |
+
+### Z0-AC13 — Privacy : pas de persistance des photos
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Un job déposé puis terminé. |
+| **WHEN** | On inspecte le filesystem du pod et l'état mémoire après expiration TTL. |
+| **THEN** | (a) Les photos n'ont jamais été écrites sur disque (lecture en mémoire uniquement). (b) Au-delà de `JOB_TTL_SECONDS` (par défaut 3600 s), `JOBS[id]` et `JOB_HTML[id]` sont purgés. (c) Pas de log qui contient le contenu base64 des images (seulement la taille et le mime). (d) Pas de stockage S3/MinIO/DB côté Lot -1. |
+
+### Z0-AC14 — Pas d'authentification mais protection minimale
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Le service exposé publiquement sur `revise-lab.musso.io`. |
+| **WHEN** | Un visiteur accède sans compte. |
+| **THEN** | (a) Aucun login requis. (b) Une protection rate-limit ou Cloudflare Access (zero-trust, autoriser e-mail family) limite l'usage à un cercle de confiance. (c) `/preview`, `/preview/raw`, `/healthz` peuvent rester ouverts ; `POST /jobs` doit être derrière le filtre. (d) Pas de leak de la version de l'image, du nom du modèle LLM ou de l'URL interne dans les réponses. |
+
+### Z0-AC15 — Déploiement par image OCI publique
+| | |
+|---|---|
+| **Lot -1** | bloquant |
+| **GIVEN** | Un push sur `web-v0/**` du dépôt ReviseMieux. |
+| **WHEN** | Le workflow `web-v0 image` s'exécute. |
+| **THEN** | L'image `ghcr.io/popul/revisemieux-web-v0` est build (Buildx + cache GHA) et push avec les tags `sha-<short>`, `branch-<name>` et — uniquement sur `reboot`/`main` — `latest`. Le package GHCR est public, K3s peut pull sans `imagePullSecrets`. Le manifeste Deployment dans le dépôt `homelab` (`services/revise/deployment.yaml`) référence l'image et le rolling update est automatique via ArgoCD. |

--- a/docs/lot-minus-1-tracker.md
+++ b/docs/lot-minus-1-tracker.md
@@ -1,0 +1,103 @@
+# Suivi Lot -1 — Révise Mieux (web-v0)
+
+| | |
+|---|---|
+| **Périmètre** | 15 ACs (Z0) · site web one-page autonome · pas de DB, pas de comptes |
+| **Démarrage** | 2026-04-28 (premier déploiement homelab) |
+| **Code** | [`web-v0/`](../web-v0/) · [`prompts/study-guide/`](../prompts/study-guide/) |
+| **Production** | `https://revise-lab.musso.io/` (homelab K3s + Cloudflare) |
+| **Image** | `ghcr.io/popul/revisemieux-web-v0` (publique) |
+
+---
+
+## Légende statut
+
+| Icône | Statut |
+|---|---|
+| `[ ]` | À faire |
+| `[~]` | En cours |
+| `[x]` | Terminé |
+| `[—]` | Bloqué / en attente |
+
+---
+
+## Phase 0 — Shell & schéma
+
+Précondition de toute le reste : un chrome HTML stable et déterministe.
+
+| # | Tâche | Statut | ACs couvertes | Livrables |
+|---|---|---|---|---|
+| 0.1 | Shell Jinja2 mobile-first avec drawer hamburger fonctionnel | `[x]` | Z0-AC04, Z0-AC07 | `web-v0/shell.html.j2` |
+| 0.2 | Deux boutons d'impression (élève / parent) avec safe-area iOS | `[x]` | Z0-AC05, Z0-AC06 | `web-v0/shell.html.j2` |
+| 0.3 | Schéma Pydantic `Fiche` couvrant Sections 1-6 + 8 + 9 | `[x]` | Z0-AC11 | `web-v0/schema.py` |
+| 0.4 | Endpoint `/preview` qui rend une fixture sans appel LLM | `[x]` | Z0-AC12 | `web-v0/main.py`, `web-v0/fixture.json` |
+| 0.5 | `@media print` complet : élève masque corrigés, parent imprime tout | `[x]` | Z0-AC06 | `web-v0/shell.html.j2` |
+| 0.6 | Theme + breakpoints responsive (768/480/landscape) | `[x]` | Z0-AC07 | `web-v0/shell.html.j2` |
+
+> **Critère de validation Phase 0 :** `GET /preview` renvoie 200 + ~46 kB de HTML autonome qui exerce toutes les sections du template ; chrome (drawer + boutons impression) testé manuellement sur Safari iOS et Chrome desktop.
+
+---
+
+## Phase 1 — Pipeline 1-stage (legacy, conservé)
+
+Première itération : un seul appel LLM, sortie HTML directe. Permet de livrer immédiatement avant de basculer en 2-stage.
+
+| # | Tâche | Statut | ACs couvertes | Livrables |
+|---|---|---|---|---|
+| 1.1 | Job pattern async (POST /jobs immédiat + polling) | `[x]` | Z0-AC01, Z0-AC09 | `web-v0/main.py` |
+| 1.2 | Appel LLM Qwen 3.6 35B-A3B (vision + thinking) via LM Studio | `[x]` | Z0-AC01 | `web-v0/main.py` `_run_llm` |
+| 1.3 | Logs structurés par job (created/llm_request/llm_response/html) | `[x]` | Z0-AC10 | `web-v0/main.py` |
+| 1.4 | Strip `<think>...</think>` et bloc ```html en sortie | `[x]` | Z0-AC02 | `web-v0/main.py` |
+| 1.5 | Déploiement K3s via image GHCR publique | `[x]` | Z0-AC15 | `homelab` repo (`services/revise/`) |
+| 1.6 | Source unique du prompt (`prompts/study-guide/system.md`) | `[x]` | — | PR factorisation |
+
+> **Critère de validation Phase 1 :** une fiche cible 18-20 sur 12 photos est générée en < 5 min, présente Sections 1-6 + 8 + 9, finit par `</html>`, taille HTML > 30 kB. **Atteint** sur le run `cff6af4d-...` du 2026-04-29 (84 kB, finish=stop).
+
+---
+
+## Phase 2 — Pipeline 2-stage JSON (en cours)
+
+Bascule du LLM en producteur de JSON validé Pydantic, rendu HTML déterministe via Jinja. Élimine les régressions chrome qu'on observait avec le 1-stage.
+
+| # | Tâche | Statut | ACs couvertes | Livrables |
+|---|---|---|---|---|
+| 2.1 | Schéma Fiche complet (Pydantic v2, alias `def`/keys, énums Mastery) | `[x]` | Z0-AC11 | `web-v0/schema.py` |
+| 2.2 | Réécriture du prompt système en mode extraction JSON | `[ ]` | Z0-AC02 | `prompts/study-guide/system.md` (refonte) |
+| 2.3 | Activation `response_format: {"type":"json_object"}` côté LM Studio | `[ ]` | Z0-AC11 | `web-v0/main.py` |
+| 2.4 | Validation Pydantic stricte ; échec → job=error + message | `[ ]` | Z0-AC11 | `web-v0/main.py` |
+| 2.5 | Render Jinja `shell.html.j2` à partir du `Fiche` validé | `[~]` | Z0-AC02, Z0-AC04, Z0-AC05 | `web-v0/main.py` |
+| 2.6 | Bench comparatif latence + qualité 1-stage vs 2-stage | `[ ]` | Z0-AC08 | rapport `docs/lot-minus-1-bench.md` |
+| 2.7 | Bascule par défaut sur 2-stage, suppression du chemin 1-stage | `[ ]` | — | `web-v0/main.py` |
+
+> **Critère de validation Phase 2 :** sur les mêmes 12 photos qu'en Phase 1, la fiche 2-stage couvre tous les Z0-AC02/03 sans avoir à corriger le HTML, et le shell ne dépend plus du tout de la sortie LLM (qui ne touche plus au HTML).
+
+---
+
+## Phase 3 — Itération AC + ouverture publique
+
+Une fois le pipeline 2-stage stable, durcir les Z0-AC restants et ouvrir l'accès au-delà du dev.
+
+| # | Tâche | Statut | ACs couvertes | Livrables |
+|---|---|---|---|---|
+| 3.1 | Suite de tests d'intégration sur 4 chapitres pilotes (HG/SVT/PC/français) | `[ ]` | Z0-AC02, Z0-AC03 | `web-v0/tests/` |
+| 3.2 | Audit privacy : aucun log/disque ne contient les bytes des images | `[ ]` | Z0-AC13 | revue manuelle + checklist |
+| 3.3 | Cloudflare Access (zero-trust) pour POST /jobs (whitelist e-mail) | `[ ]` | Z0-AC14 | config Cloudflare |
+| 3.4 | Rate-limit basique côté FastAPI (slowapi ou middleware) | `[ ]` | Z0-AC14 | `web-v0/main.py` |
+| 3.5 | Auto-continuation si `finish_reason=length` (rare avec 2-stage) | `[ ]` | Z0-AC08 | `web-v0/main.py` |
+| 3.6 | Bench fréquence d'usage Louis (≥ 1 contrôle / semaine) | `[ ]` | KPI adoption | log analysis |
+
+> **Critère de validation Phase 3 :** Louis génère ≥ 5 fiches sur 4 chapitres distincts, taux de fiche utilisable au premier shot ≥ 90%, latence P95 ≤ 5 min, aucun incident privacy.
+
+---
+
+## Roadmap synthétique
+
+```
+2026-04-28  ─────  Phase 0  ✓  shell + /preview en ligne
+2026-04-29  ─────  Phase 1  ✓  pipeline 1-stage HTML
+2026-05-02  ─────  factor : prompt en source unique, image GHCR
+2026-05-??  ─────  Phase 2     pipeline 2-stage JSON
+2026-05-??  ─────  Phase 3     ouverture famille + bench
+```
+
+> Les jalons Phase 2/3 ne sont pas datés : Lot -1 reste un side track de Lot 0 (qui prime). On itère sur Lot -1 quand un usage réel le demande (un contrôle de Louis, un bug remonté, une amélioration triviale).


### PR DESCRIPTION
> **Stacked sur #100 (web-v0)** — fusionner #100 d'abord. Cette PR ajoute uniquement de la doc.

## Summary

Documente le palier Lot -1 (web-v0) dans tous les documents de référence pour qu'il devienne un livrable de premier plan, pas un side track.

- **PRD** § 1 + nouveau § 3.0 (vue d'ensemble Lot -1 / Lot 0 / MVP) + nouveau § 3.4 (détail Lot -1).
- **ac/Z0.md** : 15 critères Given/When/Then qui couvrent pipeline E2E, conformité contenu, annexes 18-20, drawer hamburger, deux boutons impression, print élève, mobile/safe-area, SLA, timeout Cloudflare, observabilité, validation Pydantic, /preview, privacy, auth, déploiement.
- **ac/README.md** : passe à 9 zones / 186 ACs, note disjonction Z0 / Z1-Z8.
- **MVP-scope.md** : ajoute légende Lot -1 (bloquant / —) et section Z0.
- **lot-minus-1-tracker.md** : tracker parallèle à `lot0-tracker.md`. Phase 0 et 1 ✓, Phase 2 en cours.

Pas de changement de numérotation des sections existantes du PRD ni des Z1-Z8 (zéro casse d'ancres).

## Test plan
- [ ] Lecture PRD § 3.0 + § 3.4
- [ ] Vérifier que chaque Z0-ACxx référencé dans Z0.md / MVP-scope.md / lot-minus-1-tracker.md est bien défini (cohérence transverse)
- [ ] mkdocs serve → vérifier que le site docs build sans broken link

🤖 Generated with [Claude Code](https://claude.com/claude-code)